### PR TITLE
fix: create BTRFS filesystems in a loop device if no BTRFS during tests. And fixed the show command

### DIFF
--- a/test.py
+++ b/test.py
@@ -128,6 +128,9 @@ class TestCase(unittest.TestCase):
         resp = jsonloads(
             self.app.post("/VolumeDriver.Create", json.dumps({"Name": name})).body
         )
+        # Debug: check if volume creation had errors
+        if resp.get("Err") != "":
+            self.fail(f"Volume creation failed: {resp}")
         self.assertEqual(resp, {"Err": ""})
 
         # get
@@ -136,12 +139,22 @@ class TestCase(unittest.TestCase):
         )
         # Debug: show detailed info if Volume key is missing
         if "Volume" not in resp:
+            # Check if it's actually a BTRFS subvolume
+            try:
+                from subprocess import run, PIPE
+                result = run(f'btrfs subvolume show "{path}"', shell=True, 
+                           capture_output=True, text=True)
+                btrfs_status = f"BTRFS show exit code: {result.returncode}, stdout: {result.stdout[:100]}, stderr: {result.stderr[:100]}"
+            except Exception as e:
+                btrfs_status = f"BTRFS show failed: {e}"
+            
             debug_info = (
                 f"Volume key missing from response. "
                 f"Response: {resp}, "
                 f"Path exists: {os.path.exists(path)}, "
                 f"Path is dir: {os.path.isdir(path) if os.path.exists(path) else 'N/A'}, "
-                f"Volume path: {path}"
+                f"Volume path: {path}, "
+                f"BTRFS status: {btrfs_status}"
             )
             self.fail(debug_info)
         self.assertEqual(resp["Volume"]["Name"], name)

--- a/test.py
+++ b/test.py
@@ -128,35 +128,12 @@ class TestCase(unittest.TestCase):
         resp = jsonloads(
             self.app.post("/VolumeDriver.Create", json.dumps({"Name": name})).body
         )
-        # Debug: check if volume creation had errors
-        if resp.get("Err") != "":
-            self.fail(f"Volume creation failed: {resp}")
         self.assertEqual(resp, {"Err": ""})
 
         # get
         resp = jsonloads(
             self.app.post("/VolumeDriver.Get", json.dumps({"Name": name})).body
         )
-        # Debug: show detailed info if Volume key is missing
-        if "Volume" not in resp:
-            # Check if it's actually a BTRFS subvolume
-            try:
-                from subprocess import run, PIPE
-                result = run(f'btrfs subvolume show "{path}"', shell=True, 
-                           capture_output=True, text=True)
-                btrfs_status = f"BTRFS show exit code: {result.returncode}, stdout: {result.stdout[:100]}, stderr: {result.stderr[:100]}"
-            except Exception as e:
-                btrfs_status = f"BTRFS show failed: {e}"
-            
-            debug_info = (
-                f"Volume key missing from response. "
-                f"Response: {resp}, "
-                f"Path exists: {os.path.exists(path)}, "
-                f"Path is dir: {os.path.isdir(path) if os.path.exists(path) else 'N/A'}, "
-                f"Volume path: {path}, "
-                f"BTRFS status: {btrfs_status}"
-            )
-            self.fail(debug_info)
         self.assertEqual(resp["Volume"]["Name"], name)
         self.assertEqual(resp["Volume"]["Mountpoint"], path)
         self.assertEqual(resp["Err"], "")

--- a/test.py
+++ b/test.py
@@ -134,11 +134,16 @@ class TestCase(unittest.TestCase):
         resp = jsonloads(
             self.app.post("/VolumeDriver.Get", json.dumps({"Name": name})).body
         )
-        # Debug: print response if test fails
+        # Debug: show detailed info if Volume key is missing
         if "Volume" not in resp:
-            print(f"DEBUG: Get volume response: {resp}")
-            print(f"DEBUG: Volume path exists: {os.path.exists(path)}")
-            print(f"DEBUG: Volume path is dir: {os.path.isdir(path) if os.path.exists(path) else 'N/A'}")
+            debug_info = (
+                f"Volume key missing from response. "
+                f"Response: {resp}, "
+                f"Path exists: {os.path.exists(path)}, "
+                f"Path is dir: {os.path.isdir(path) if os.path.exists(path) else 'N/A'}, "
+                f"Volume path: {path}"
+            )
+            self.fail(debug_info)
         self.assertEqual(resp["Volume"]["Name"], name)
         self.assertEqual(resp["Volume"]["Mountpoint"], path)
         self.assertEqual(resp["Err"], "")

--- a/test.py
+++ b/test.py
@@ -134,6 +134,11 @@ class TestCase(unittest.TestCase):
         resp = jsonloads(
             self.app.post("/VolumeDriver.Get", json.dumps({"Name": name})).body
         )
+        # Debug: print response if test fails
+        if "Volume" not in resp:
+            print(f"DEBUG: Get volume response: {resp}")
+            print(f"DEBUG: Volume path exists: {os.path.exists(path)}")
+            print(f"DEBUG: Volume path is dir: {os.path.isdir(path) if os.path.exists(path) else 'N/A'}")
         self.assertEqual(resp["Volume"]["Name"], name)
         self.assertEqual(resp["Volume"]["Mountpoint"], path)
         self.assertEqual(resp["Err"], "")


### PR DESCRIPTION
Tests were failing because of a hardcoded show command.
I implemented a fix for the show command and allow to create a BTRFS filesystem just for tests
