### PR TITLE
fix: Auto-create config and ssh directories on plugin start

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Build stage - includes development tools
 FROM debian:12 AS builder
-MAINTAINER Christophe Combelles. <ccomb@prelab.fr>
+MAINTAINER Christophe Combelles. <ccomb@free.fr>
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
         python3 \
@@ -23,7 +23,7 @@ RUN mkdir /usr/src/buttervolume \
 
 # Runtime stage - minimal dependencies
 FROM debian:12-slim
-LABEL maintainer="Christophe Combelles <ccomb@prelab.fr>"
+LABEL maintainer="Christophe Combelles <ccomb@free.fr>"
 
 # Install runtime dependencies and create directories in one layer
 RUN apt-get update \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,6 +2,11 @@
 
 SSH_PORT=${SSH_PORT:-1122}
 
+# Ensure required directories exist in the mounted volume
+# These will appear on the host at /var/lib/buttervolume/{config,ssh}
+mkdir -p /var/lib/buttervolume/config
+mkdir -p /var/lib/buttervolume/ssh
+
 chown -R root: /root/
 sed -r "s/[#]{0,1}Port [0-9]{2,5}/Port $SSH_PORT/g" /etc/ssh/sshd_config -i
 service ssh start

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,7 +3,8 @@
 SSH_PORT=${SSH_PORT:-1122}
 
 # Ensure required directories exist in the mounted volume
-# These will appear on the host at /var/lib/buttervolume/{config,ssh}
+# /var/lib/buttervolume/config (host) -> /etc/buttervolume (container)
+# /var/lib/buttervolume/ssh (host) -> /root/.ssh (container)
 mkdir -p /var/lib/buttervolume/config
 mkdir -p /var/lib/buttervolume/ssh
 


### PR DESCRIPTION
##  :wrench: Problem

  Users reported problem with creating a config in /var/lib/buttervolume/config in #33. Not sure what the real problem is, Maybe some confusion or unclear documentation

##  :cake: Solution

The entrypoint script now automatically creates these directories in the mounted volume on startup, in case it's not created

