### PR TITLE
Give the configuration its own module

### DIFF
--- a/buttervolume/api.py
+++ b/buttervolume/api.py
@@ -30,13 +30,17 @@ from bottle import app
 from requests.exceptions import ConnectionError
 from webtest import TestApp
 
-from buttervolume.plugin import USOCKET
+import buttervolume.plugin  # noqa: F401  this import is what posts the routes
+from buttervolume.config import USOCKET
 
 log = logging.getLogger()
 
 # The Bottle application the plugin has posted its routes on. Importing
-# plugin.py is what puts them there, hence the import above, which also gives
-# us the socket they answer on.
+# plugin.py is what puts them there, and nothing else in the daemon imports it:
+# without the line above, `buttervolume run` serves an application without a
+# single route, and says nothing. The test suite cannot see that, because it
+# imports plugin.py on its own, which is why one test starts a fresh
+# interpreter to check it.
 app = app()
 
 

--- a/buttervolume/cli.py
+++ b/buttervolume/cli.py
@@ -33,8 +33,7 @@ from waitress import serve
 
 from buttervolume import ValidationError, api
 from buttervolume.api import app
-from buttervolume.init import init_btrfs
-from buttervolume.plugin import (
+from buttervolume.config import (
     LOGLEVEL,
     SCHEDULE,
     SNAPSHOTS_PATH,
@@ -42,6 +41,7 @@ from buttervolume.plugin import (
     TIMER,
     VOLUMES_PATH,
 )
+from buttervolume.init import init_btrfs
 from buttervolume.purge import Pattern
 from buttervolume.schedule import Job, Purge, read_schedule, write_schedule
 from buttervolume.scheduler import scheduler

--- a/buttervolume/config.py
+++ b/buttervolume/config.py
@@ -1,0 +1,73 @@
+"""Everything that is decided once, at startup, and never again.
+
+An environment variable wins over `/etc/buttervolume/config.ini`, which wins
+over the default written here; `getconfig` is that rule, and nobody else has to
+know it. What lives here is a value read at import time: a directory, a delay,
+the socket to answer on. Nothing that touches BTRFS, a volume or a request.
+
+Every other module reads its settings here rather than from `plugin.py`, so
+that knowing where the snapshots live no longer means importing the whole HTTP
+server. They import the names, never the module, because the test suite
+replaces some of these names in the namespace of the module that reads them.
+"""
+
+import configparser
+import json
+import logging
+import os
+from subprocess import run
+
+config = configparser.ConfigParser()
+config.read("/etc/buttervolume/config.ini")
+
+
+def getconfig(config, var, default):
+    """read the var from the environ, then config file, then default"""
+    return os.environ.get("BUTTERVOLUME_" + var) or config["DEFAULT"].get(var, default)
+
+
+# overrideable defaults with config file
+VOLUMES_PATH = getconfig(config, "VOLUMES_PATH", "/var/lib/buttervolume/volumes/")
+SNAPSHOTS_PATH = getconfig(config, "SNAPSHOTS_PATH", "/var/lib/buttervolume/snapshots/")
+TEST_REMOTE_PATH = getconfig(config, "TEST_REMOTE_PATH", "/var/lib/buttervolume/received/")
+SCHEDULE = getconfig(config, "SCHEDULE", "/etc/buttervolume/schedule.csv")
+SCHEDULE_DISABLED = f"{SCHEDULE}.disabled"
+LAST_RUNS = getconfig(config, "LAST_RUNS", "/var/lib/buttervolume/lastruns.csv")
+# Support both old and new plugin names for backward compatibility
+DRIVERNAME = getconfig(config, "DRIVERNAME", "ccomb/buttervolume:latest")
+LEGACY_DRIVERNAME = "anybox/buttervolume:latest"
+RUNPATH = getconfig(config, "RUNPATH", "/run/docker")
+SOCKET = getconfig(config, "SOCKET", os.path.join(RUNPATH, "plugins", "btrfs.sock"))
+USOCKET = SOCKET
+if not os.path.exists(USOCKET):
+    # socket path on the host or another container
+    # Try current plugin name first, then legacy name for backward compatibility
+    for driver_name in [DRIVERNAME, LEGACY_DRIVERNAME]:
+        try:
+            plugins = json.loads(
+                run(
+                    f"docker plugin inspect {driver_name}",
+                    shell=True,
+                    capture_output=True,
+                ).stdout.decode()
+                or "[]"
+            )
+            if plugins:
+                plugin = plugins[0]  # can we have several plugins with the same name?
+                USOCKET = os.path.join(RUNPATH, "plugins", plugin["Id"], "btrfs.sock")
+                break
+        except Exception:
+            continue  # Try next driver name
+
+TIMER = int(getconfig(config, "TIMER", 60))
+# How long each external command may legitimately take, in seconds. These two
+# are not read from the configuration file, but they are delays like the next
+# one and are read next to it.
+SYNC_TIMEOUT = 30
+RSYNC_TIMEOUT = 600
+# The send crosses the network, so its limit is configurable like the rest
+SEND_TIMEOUT = int(getconfig(config, "SEND_TIMEOUT", 600))
+DTFORMAT = getconfig(config, "DTFORMAT", "%Y-%m-%dT%H:%M:%S.%f")
+LOGLEVEL = getattr(logging, getconfig(config, "LOGLEVEL", "INFO"))
+
+logging.basicConfig(level=LOGLEVEL)

--- a/buttervolume/plugin.py
+++ b/buttervolume/plugin.py
@@ -5,14 +5,13 @@ decorators is the authoritative route list. ``@route`` is defined here too, and
 is not Bottle's: it decodes the request, logs it, and turns any failure into
 the ``Err`` field of a 200 answer, which is the only shape a client can read.
 
-This is also where the directories are configured, so this is where a name
-turns into a path on disk, and where it is validated as it does. What a name is
+This is where a name turns into a path on disk, and where it is validated as it
+does; the directories it is joined to come from ``config.py``. What a name is
 worth is decided in ``names.py``, what a retention pattern says in ``purge.py``,
 what a scheduled action asks for in ``schedule.py``; none of them knows these
 directories, and the schedule file is read and written there rather than here.
 """
 
-import configparser
 import json
 import logging
 import os
@@ -23,7 +22,6 @@ from dataclasses import replace
 from datetime import datetime
 from functools import wraps
 from os.path import basename, dirname, join
-from subprocess import run
 
 from bottle import request
 from bottle import route as bottle_route
@@ -37,6 +35,17 @@ from buttervolume import (
     btrfs,
 )
 from buttervolume.btrfs import BtrfsError
+from buttervolume.config import (
+    DTFORMAT,
+    RSYNC_TIMEOUT,
+    SCHEDULE,
+    SCHEDULE_DISABLED,
+    SEND_TIMEOUT,
+    SNAPSHOTS_PATH,
+    SYNC_TIMEOUT,
+    TEST_REMOTE_PATH,
+    VOLUMES_PATH,
+)
 from buttervolume.names import (
     Snapshot,
     new_snapshot,
@@ -49,58 +58,6 @@ from buttervolume.names import (
 from buttervolume.purge import Pattern, compute_purges
 from buttervolume.schedule import Entry, Job, read_schedule, write_schedule
 
-config = configparser.ConfigParser()
-config.read("/etc/buttervolume/config.ini")
-
-
-def getconfig(config, var, default):
-    """read the var from the environ, then config file, then default"""
-    return os.environ.get("BUTTERVOLUME_" + var) or config["DEFAULT"].get(var, default)
-
-
-# overrideable defaults with config file
-VOLUMES_PATH = getconfig(config, "VOLUMES_PATH", "/var/lib/buttervolume/volumes/")
-SNAPSHOTS_PATH = getconfig(config, "SNAPSHOTS_PATH", "/var/lib/buttervolume/snapshots/")
-TEST_REMOTE_PATH = getconfig(config, "TEST_REMOTE_PATH", "/var/lib/buttervolume/received/")
-SCHEDULE = getconfig(config, "SCHEDULE", "/etc/buttervolume/schedule.csv")
-SCHEDULE_DISABLED = f"{SCHEDULE}.disabled"
-LAST_RUNS = getconfig(config, "LAST_RUNS", "/var/lib/buttervolume/lastruns.csv")
-# Support both old and new plugin names for backward compatibility
-DRIVERNAME = getconfig(config, "DRIVERNAME", "ccomb/buttervolume:latest")
-LEGACY_DRIVERNAME = "anybox/buttervolume:latest"
-RUNPATH = getconfig(config, "RUNPATH", "/run/docker")
-SOCKET = getconfig(config, "SOCKET", os.path.join(RUNPATH, "plugins", "btrfs.sock"))
-USOCKET = SOCKET
-if not os.path.exists(USOCKET):
-    # socket path on the host or another container
-    # Try current plugin name first, then legacy name for backward compatibility
-    for driver_name in [DRIVERNAME, LEGACY_DRIVERNAME]:
-        try:
-            plugins = json.loads(
-                run(
-                    f"docker plugin inspect {driver_name}",
-                    shell=True,
-                    capture_output=True,
-                ).stdout.decode()
-                or "[]"
-            )
-            if plugins:
-                plugin = plugins[0]  # can we have several plugins with the same name?
-                USOCKET = os.path.join(RUNPATH, "plugins", plugin["Id"], "btrfs.sock")
-                break
-        except Exception:
-            continue  # Try next driver name
-
-TIMER = int(getconfig(config, "TIMER", 60))
-# How long each external command may legitimately take, in seconds
-SYNC_TIMEOUT = 30
-RSYNC_TIMEOUT = 600
-# The send crosses the network, so its limit is configurable like the rest
-SEND_TIMEOUT = int(getconfig(config, "SEND_TIMEOUT", 600))
-DTFORMAT = getconfig(config, "DTFORMAT", "%Y-%m-%dT%H:%M:%S.%f")
-LOGLEVEL = getattr(logging, getconfig(config, "LOGLEVEL", "INFO"))
-
-logging.basicConfig(level=LOGLEVEL)
 log = logging.getLogger()
 
 

--- a/buttervolume/scheduler.py
+++ b/buttervolume/scheduler.py
@@ -26,7 +26,7 @@ from os.path import exists
 from subprocess import CalledProcessError
 
 from buttervolume import ReplicationError, ValidationError, api
-from buttervolume.plugin import LAST_RUNS, SCHEDULE, TIMER
+from buttervolume.config import LAST_RUNS, SCHEDULE, TIMER
 from buttervolume.schedule import (
     Entry,
     Job,

--- a/test.py
+++ b/test.py
@@ -13,6 +13,7 @@ import os
 import shutil
 import stat
 import subprocess
+import sys
 import tempfile
 import threading
 import time
@@ -28,18 +29,18 @@ from unittest.mock import MagicMock, patch
 from webtest import TestApp
 
 from buttervolume import ValidationError, btrfs, cli, plugin, schedule, scheduler
+from buttervolume.config import (
+    DTFORMAT,
+    SNAPSHOTS_PATH,
+    TEST_REMOTE_PATH,
+    VOLUMES_PATH,
+)
 from buttervolume.init import init_btrfs
 from buttervolume.names import (
     Snapshot,
     new_snapshot,
     sent_snapshots,
     snapshots_of,
-)
-from buttervolume.plugin import (
-    DTFORMAT,
-    SNAPSHOTS_PATH,
-    TEST_REMOTE_PATH,
-    VOLUMES_PATH,
 )
 from buttervolume.purge import Pattern, compute_purges
 from buttervolume.schedule import (
@@ -1393,6 +1394,30 @@ class TestCase(unittest.TestCase):
     def test_capabilities(self):
         rsp = jsonloads(self.app.post("/VolumeDriver.Capabilities", "{}").body)
         self.assertEqual(rsp.get("Capabilities", {}).get("Scope"), "local")
+
+
+class TestTheDaemonServesItsRoutes(unittest.TestCase):
+    """What `buttervolume run` would answer, asked from a fresh interpreter.
+
+    The routes are posted on the default Bottle application as a side effect of
+    importing plugin.py, and api.py is the only place in the daemon that
+    imports it. The rest of this file cannot see that import disappear, because
+    it imports plugin.py on its own, and the application would look full here
+    while the daemon served nothing. Hence a new interpreter, which imports
+    exactly what the daemon imports and nothing more.
+    """
+
+    def test_importing_the_api_is_enough_to_have_the_routes(self):
+        result = subprocess.run(
+            [sys.executable, "-c", "from buttervolume.api import app; assert app.routes"],
+            capture_output=True,
+        )
+        self.assertEqual(
+            result.returncode,
+            0,
+            "the daemon would serve an application without a single route: "
+            + result.stderr.decode(),
+        )
 
 
 class TestNames(unittest.TestCase):


### PR DESCRIPTION
Knowing where the snapshots live, or how many minutes the scheduler waits, meant importing `plugin.py`, and with it the whole HTTP server. `api.py` did it for a socket path, `scheduler.py` for two file names and a delay, `cli.py` for six constants. None of those three wants the server; they want the configuration, which only happened to be written in the same file.

Those settings now live in `config.py`: the constants, the reading of `config.ini`, the socket discovery and `logging.basicConfig`. Nothing there knows about a volume or a request. Every value keeps the value and the order it had; this pull request moves lines, it does not change one.

## The import that had to become visible

`api.py` keeps its import of `plugin.py`, written out this time, because that import is also what posts the twenty-two routes on the Bottle application. Nothing else in the daemon imports `plugin.py` any more, so without that line `buttervolume run` would serve an application without a single route, and say nothing about it.

The test suite cannot see that happen: it imports `plugin.py` on its own account, and `bottle.AppStack.__call__` always returns the same object, so the routes would look present here while the daemon served nothing. A new test therefore asks a fresh interpreter the only question that matters: importing the API, are there routes? Removing the import from `api.py` makes it fail with "the daemon would serve an application without a single route", and putting it back makes it pass. That was checked both ways rather than assumed.

## What this does not do

It does not move `run_btrfs_send_receive` out into a `replication.py`. That was planned, and dropped after review: the function has a single caller, the only gain would be a purer docstring, and it alone would have forced a second stacked branch and a circular import risk. Sixty-five lines of plumbing in a module of six hundred are not worth a module of their own.

It does not split the route table, which would turn the import above into a permanent trap, multiplied by three. It does not touch the full-send fallback inside `snapshot_send`, which would be rewriting rather than moving. And it adds nothing to `CHANGES.rst`: no message, no answer and no command changes.

## Verification

`./test_local.sh`: 74 passed, 4 skipped for lack of SSH, the same four as before, and the same 73 tests plus the new one. `ruff check` and `ruff format --check` clean.