### PR TITLE
A purge no longer deletes what a send still needs

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,14 @@ CHANGELOG
 3.13 (unreleased)
 *****************
 
+- A purge no longer deletes what a replication needs. The trace of the last
+  send to a host is a snapshot like any other, with a date the purge could
+  read, so a retention pattern would delete it along with the snapshot it was
+  made from. The next send then found no parent and carried the whole volume
+  over the network again, which is exactly what an incremental send is there to
+  avoid. The pair is now kept whatever the pattern says, and the README says
+  that a host you stop replicating to leaves a pair to delete by hand.
+
 - Buttervolume now says it needs Python 3.11 or later. Nothing declared it, so
   each version of ``uv`` invented its own floor and rewrote ``uv.lock`` on the
   next command it was given, and an installation on an older Python failed on

--- a/README.rst
+++ b/README.rst
@@ -600,6 +600,13 @@ Here are a few examples of retention patterns:
     refused, and which ``buttervolume scheduled --auto-convert-old-patterns``
     rewrites in the schedule.
 
+Whatever the pattern says, a purge never deletes what a replication needs: the
+trace of the last send to a host, named ``<volume>@<datetime>@<host>``, and the
+snapshot it was made from, which is the parent the next incremental send is
+built on. Deleting them would send the whole volume over the network again. So
+when you stop replicating a volume to a host, delete that pair by hand,
+otherwise it stays there for good.
+
 
 Schedule a job
 --------------

--- a/buttervolume/purge.py
+++ b/buttervolume/purge.py
@@ -19,7 +19,7 @@ import logging
 from dataclasses import dataclass
 
 from buttervolume import ValidationError
-from buttervolume.names import Snapshot
+from buttervolume.names import Snapshot, parsed
 
 log = logging.getLogger()
 
@@ -70,6 +70,16 @@ class Pattern:
 def compute_purges(snapshots, pattern, now, dtformat):
     """Return the list of snapshots this pattern condemns, at this moment."""
     snapshots = sorted(snapshots)
+    # a purge does not delete what a send still needs: the trace of a send, and
+    # the snapshot it was made from, which is the parent the next incremental
+    # send is built on. Both are taken out of the answer rather than out of the
+    # input, because a name missing from the input frees its timeframe below,
+    # and a neighbour that should die would survive in its place.
+    needed = set()
+    for s in parsed(snapshots):
+        if s.host:
+            needed.add(str(s))
+            needed.add(str(s.without_host()))
     ages = list(reversed(pattern.minutes))
     purge_list = []
     max_age = ages[0]
@@ -86,29 +96,26 @@ def compute_purges(snapshots, pattern, now, dtformat):
             continue
         snapshots_age.append(int(age.total_seconds()) / 60)
         valid_snapshots.append(s)
-    if not valid_snapshots:
-        return purge_list
-
     # A single specifier ("2h" -> [120]) deletes everything past the threshold
     if len(ages) == 1:
-        return [s for s, age in zip(valid_snapshots, snapshots_age) if age > ages[0]]
-
-    # Several specifiers ("2h:1d:1w" -> [10080, 1440, 120]) keep one snapshot
-    # per timeframe inside each segment.
-    # age segments = [(10080, 1440), (1440, 120)]
-    for age_segment in [(ages[i], ages[i + 1]) for i, _ in enumerate(ages[:-1])]:
-        last_timeframe = -1
-        for i, age in enumerate(snapshots_age):
-            # if the age is outside the age_segment, delete nothing.
-            # Only 70 and 90 are inside the age_segment (60, 180)
-            if age > age_segment[0] < max_age or age < age_segment[1]:
-                continue
-            # Now get the timeframe number of the snapshot.
-            # Ages 70 and 90 are in the same timeframe (70//60 == 90//60)
-            timeframe = age // age_segment[1]
-            # delete if we already had a snapshot in the same timeframe
-            # or if the snapshot is very old
-            if timeframe == last_timeframe or age > max_age:
-                purge_list.append(valid_snapshots[i])
-            last_timeframe = timeframe
-    return purge_list
+        purge_list = [s for s, age in zip(valid_snapshots, snapshots_age) if age > ages[0]]
+    else:
+        # Several specifiers ("2h:1d:1w" -> [10080, 1440, 120]) keep one snapshot
+        # per timeframe inside each segment.
+        # age segments = [(10080, 1440), (1440, 120)]
+        for age_segment in [(ages[i], ages[i + 1]) for i, _ in enumerate(ages[:-1])]:
+            last_timeframe = -1
+            for i, age in enumerate(snapshots_age):
+                # if the age is outside the age_segment, delete nothing.
+                # Only 70 and 90 are inside the age_segment (60, 180)
+                if age > age_segment[0] < max_age or age < age_segment[1]:
+                    continue
+                # Now get the timeframe number of the snapshot.
+                # Ages 70 and 90 are in the same timeframe (70//60 == 90//60)
+                timeframe = age // age_segment[1]
+                # delete if we already had a snapshot in the same timeframe
+                # or if the snapshot is very old
+                if timeframe == last_timeframe or age > max_age:
+                    purge_list.append(valid_snapshots[i])
+                last_timeframe = timeframe
+    return [s for s in purge_list if s not in needed]

--- a/buttervolume/purge.py
+++ b/buttervolume/purge.py
@@ -68,7 +68,11 @@ class Pattern:
 
 
 def compute_purges(snapshots, pattern, now, dtformat):
-    """Return the list of snapshots this pattern condemns, at this moment."""
+    """Return the list of snapshots this pattern condemns, at this moment.
+
+    Never the trace of a send, nor the snapshot it was made from: whatever
+    the pattern says, a replication keeps the parent its next send needs.
+    """
     snapshots = sorted(snapshots)
     # a purge does not delete what a send still needs: the trace of a send, and
     # the snapshot it was made from, which is the parent the next incremental

--- a/test.py
+++ b/test.py
@@ -925,6 +925,30 @@ class TestCase(unittest.TestCase):
         cleanup_snapshots()
         self.app.post("/VolumeDriver.Remove", json.dumps({"Name": name}))
 
+    def test_a_purge_does_not_delete_what_a_send_still_needs(self):
+        """The trace of a send, and its snapshot, outlive a purge of their age"""
+        name = PREFIX_TEST_VOLUME + uuid.uuid4().hex
+        self.create_a_volume_with_a_file(name)
+        # a snapshot older than the pattern below, and the trace of its send
+        old = (datetime.now() - timedelta(hours=3)).strftime(DTFORMAT)
+        snap = f"{name}@{old}"
+        trace = f"{snap}@127.1.2.3"
+        volume = btrfs.Subvolume(join(VOLUMES_PATH, name))
+        volume.snapshot(join(SNAPSHOTS_PATH, snap), readonly=True)
+        volume.snapshot(join(SNAPSHOTS_PATH, trace), readonly=True)
+
+        resp = self.app.post(
+            "/VolumeDriver.Snapshots.Purge",
+            json.dumps({"Name": name, "Pattern": "2h"}),
+        )
+        self.assertEqual(jsonloads(resp.body), {"Err": ""})
+        # without them the next send would have no parent and would cross the
+        # network with the whole volume again
+        self.assertEqual(
+            sorted(s for s in os.listdir(SNAPSHOTS_PATH) if s.startswith(name + "@")),
+            sorted([snap, trace]),
+        )
+
     def test_every_route_answers_json(self):
         """One decorator, one contract: no request turns a route into a 500.
 
@@ -1479,6 +1503,46 @@ class TestPurgePattern(unittest.TestCase):
         for text in ("", "2h:", "60m:plop:3000m", "5x", "²h", "4h:2h", "2h:120m", "2h:2h:4h"):
             with self.assertRaises(ValidationError):
                 Pattern.parse(text)
+
+
+class TestWhatAPurgeCondemns(unittest.TestCase):
+    """What a purge spares for a send, read without touching a filesystem"""
+
+    now = datetime(2026, 8, 26, 12, 0, 0)
+
+    def aged(self, hours):
+        """The timestamp of a snapshot taken that many hours ago"""
+        return (self.now - timedelta(hours=hours)).strftime(DTFORMAT)
+
+    def condemned(self, names, pattern):
+        return compute_purges(names, Pattern.parse(pattern), self.now, DTFORMAT)
+
+    def test_a_trace_and_the_snapshot_it_was_made_from_are_spared(self):
+        t1, t2 = self.aged(3), self.aged(4)
+        names = [f"www@{t1}", f"www@{t1}@node2", f"www@{t2}"]
+        self.assertEqual(self.condemned(names, "2h"), [f"www@{t2}"])
+
+    def test_a_trace_whose_snapshot_is_already_gone_is_spared_too(self):
+        t1 = self.aged(3)
+        self.assertEqual(self.condemned([f"www@{t1}@node2"], "2h"), [])
+
+    def test_a_trace_does_not_spare_a_snapshot_that_is_not_its_own(self):
+        """Same moment, another volume: the trace says nothing about it"""
+        t1 = self.aged(3)
+        names = [f"www@{t1}@node2", f"other@{t1}"]
+        self.assertEqual(self.condemned(names, "2h"), [f"other@{t1}"])
+
+    def test_traces_to_several_hosts_spare_the_same_snapshot_once(self):
+        t1, t2 = self.aged(3), self.aged(4)
+        names = [f"www@{t1}", f"www@{t1}@node2", f"www@{t1}@node3", f"www@{t2}"]
+        self.assertEqual(self.condemned(names, "2h"), [f"www@{t2}"])
+
+    def test_a_spared_snapshot_still_takes_up_its_timeframe(self):
+        """Spared at the end: sparing it earlier would free the timeframe it
+        occupies, and the neighbour condemned as its duplicate would survive"""
+        old, young = self.aged(6), self.aged(5)
+        names = [f"www@{old}", f"www@{old}@node2", f"www@{young}"]
+        self.assertEqual(self.condemned(names, "4h:1d"), [f"www@{young}"])
 
 
 class TestScheduledJob(unittest.TestCase):


### PR DESCRIPTION
`snapshot_send` remembers the last send to a host by keeping a snapshot named
`volume@datetime@host`. That trace is what lets the next send carry only the
difference.

The purge could not tell it apart from a snapshot: it has a date, so
`compute_purges` condemned it, and with it the snapshot it was made from. The
next send then found no parent and sent the whole volume over the network
again. No data was lost, but the incremental send stopped being incremental.

Both names are now taken out of the purge list. Out of the *answer*, not out of
the input, and that is the part worth reading twice: with several specifiers, a
purge keeps one snapshot per timeframe, so a name missing from the input frees
the timeframe it occupies, and a neighbour that should have been deleted as a
duplicate would survive in its place. The last of the new tests is there to
fail if anyone moves the filter to the input.

Nothing collects a trace that is no longer needed, and that is a decision, not
an oversight: two immobilised subvolumes cost less than sending a whole volume
again at every purge. So a host you stop replicating to leaves a pair to delete
by hand, and the README now says so.

Tests: five pure ones in a new `TestWhatAPurgeCondemns`, plus one end to end
that purges a volume holding an old snapshot and its trace and checks both are
still there. `74 passed, 4 skipped` becomes `80 passed, 4 skipped`.