### PR TITLE
A send refuses a snapshot the remote host already has

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,15 @@ CHANGELOG
   avoid. The pair is now kept whatever the pattern says, and the README says
   that a host you stop replicating to leaves a pair to delete by hand.
 
+- Sending a snapshot the remote host already holds no longer destroys the copy
+  it has. ``buttervolume send`` sends whatever snapshot it is named, and naming
+  the same one twice made it its own parent: the send succeeded, the remote
+  receive refused the result, and the fallback deleted the good remote copy
+  before sending the whole volume again. Between the deletion and the end of
+  that transfer the remote host held nothing. The trace of the previous send is
+  now what answers the question, and a snapshot that is already there is
+  refused with an empty error rather than sent.
+
 - Buttervolume now says it needs Python 3.11 or later. Nothing declared it, so
   each version of ``uv`` invented its own floor and rewrote ``uv.lock`` on the
   next command it was given, and an installation on an older Python failed on

--- a/README.rst
+++ b/README.rst
@@ -520,6 +520,12 @@ consuming a lot of bandwith or disk space::
 to live in ``/var/lib/buttervolume/snapshots`` and is replicated to the same path on
 the remote host.
 
+What the remote host already holds is read from the trace kept locally after
+each send, named ``<volume>@<datetime>@<host>``, and nothing is asked of the
+remote host. So a snapshot whose trace is there is not sent a second time, and
+a copy deleted on the remote host behind Buttervolume's back goes unnoticed:
+delete the trace as well, and the next send carries the whole volume again.
+
 
 ``<host>`` is the hostname or IP address of the remote host. The snapshot is
 currently sent using BTRFS send/receive through ssh, with an ssh server direcly

--- a/buttervolume/plugin.py
+++ b/buttervolume/plugin.py
@@ -376,8 +376,17 @@ def snapshot_send(req):
     # the previous send to that host left a trace: its snapshot is the parent
     # this one can be sent against
     already_sent = sent_snapshots(snapshot.volume, remote_host, os.listdir(SNAPSHOTS_PATH))
-    latest = str(already_sent[-1].without_host()) if already_sent else None
-    parent_path = snapshotpath(latest) if latest else None
+    if snapshot in {t.without_host() for t in already_sent}:
+        # a trace says this very snapshot is already there. Sending it again
+        # would name its own parent, the remote receive would refuse it, and
+        # the fallback below would delete the good remote copy before sending
+        # the whole volume again. Any of the traces, not just the last one:
+        # two of them coexist when a send stopped between writing the new one
+        # and deleting the old.
+        log.info("Snapshot %s is already on %s, nothing to send", snapshot_name, remote_host)
+        return {"Err": ""}
+    latest = already_sent[-1].without_host() if already_sent else None
+    parent_path = snapshotpath(str(latest)) if latest else None
     port = os.getenv("SSH_PORT", "1122")
 
     try:

--- a/test.py
+++ b/test.py
@@ -519,6 +519,56 @@ class TestCase(unittest.TestCase):
             btrfs.Subvolume(remote_path2).show()["Parent UUID"],
         )
 
+    def test_a_snapshot_the_remote_already_has_is_not_sent_again(self):
+        """The trace of a send is what says the remote already holds it"""
+        name = PREFIX_TEST_VOLUME + uuid.uuid4().hex
+        self.create_a_volume_with_a_file(name)
+        resp = self.app.post("/VolumeDriver.Snapshot", json.dumps({"Name": name}))
+        snapshot = jsonloads(resp.body)["Snapshot"]
+        # the trace a previous send to that host left behind
+        trace = f"{snapshot}@localhost"
+        btrfs.Subvolume(join(SNAPSHOTS_PATH, snapshot)).snapshot(
+            join(SNAPSHOTS_PATH, trace), readonly=True
+        )
+
+        resp = self.app.post(
+            "/VolumeDriver.Snapshot.Send",
+            json.dumps({"Name": snapshot, "Host": "localhost", "Test": True}),
+        )
+        self.assertEqual(jsonloads(resp.body), {"Err": ""})
+        # nothing crossed the network, and no second trace was written
+        self.assertEqual([s for s in os.listdir(TEST_REMOTE_PATH) if s.startswith(name)], [])
+        self.assertEqual(
+            sorted(s for s in os.listdir(SNAPSHOTS_PATH) if s.startswith(name + "@")),
+            sorted([snapshot, trace]),
+        )
+
+    @unittest.skipIf(
+        os.environ.get("BUTTERVOLUME_LOCAL_TEST"), "SSH not available in local test mode"
+    )
+    def test_sending_the_same_snapshot_twice_leaves_the_remote_copy_whole(self):
+        """The second send is refused rather than deleting the copy of the first"""
+        name = PREFIX_TEST_VOLUME + uuid.uuid4().hex
+        self.create_a_volume_with_a_file(name)
+        resp = self.app.post("/VolumeDriver.Snapshot", json.dumps({"Name": name}))
+        snapshot = jsonloads(resp.body)["Snapshot"]
+        for _ in range(2):
+            resp = self.app.post(
+                "/VolumeDriver.Snapshot.Send",
+                json.dumps({"Name": snapshot, "Host": "localhost", "Test": True}),
+            )
+            self.assertEqual(jsonloads(resp.body), {"Err": ""})
+        self.assertEqual(
+            [s for s in os.listdir(TEST_REMOTE_PATH) if s.startswith(name)], [snapshot]
+        )
+
+        # restoring the remote copy is the only proof that it is whole: a copy
+        # deleted and sent again counts exactly the same as one left alone
+        target = PREFIX_TEST_VOLUME + uuid.uuid4().hex
+        btrfs.Subvolume(join(TEST_REMOTE_PATH, snapshot)).snapshot(join(VOLUMES_PATH, target))
+        with open(join(VOLUMES_PATH, target, "foobar")) as f:
+            self.assertEqual(f.read(), "foobar")
+
     def test_snapshot(self):
         """Check we can snapshot a volume"""
         # create a volume with a file


### PR DESCRIPTION
`buttervolume send <host> <snapshot>` sends whatever snapshot it is named, and
nothing stopped anyone from naming the same one twice.

The second call then computes the snapshot itself as its own parent. That is
not caught where you would hope: `btrfs send -p X X` returns 0 and produces a
valid stream whose `parent_uuid` is its own `uuid`. It is the remote receive
that refuses it, with `File exists`, and by then `snapshot_send` is in its
fallback path, which deletes the remote copy and sends the whole volume again.
Between that deletion and the end of the transfer, the remote host holds
nothing at all. That is the bug this fixes, and it stands on its own: the
scheduled replication never meets it, because it always takes a fresh snapshot.

The trace of the previous send is what answers the question now, and membership
in the set of traces rather than a comparison with the last one: two traces
coexist when a send stopped between writing the new one and deleting the old,
and resending the snapshot of the older one by hand would fall into the same
trap. Same cost, one case less.

Nothing is asked of the remote host, deliberately: no SSH round trip is added,
so a remote copy deleted behind Buttervolume's back goes unnoticed. Deleting
the local trace forces a full send, and the README now says so.

Tests: one local, which fails without the guard because the send is then
attempted and dies for want of an SSH server. And one under Docker that sends
the same snapshot twice and then **restores** the remote copy to read the file
back, since a copy destroyed and rebuilt counts exactly like one left alone.

Note on the counts: this adds a fifth test to the four skipped in local mode.
`74 passed, 4 skipped` becomes `75 passed, 5 skipped` under `test_local.sh`, and
the fifth one runs under `./test.sh`.