### PR TITLE
A volume nobody wrote to is not snapshotted again

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,22 @@ CHANGELOG
   avoid. The pair is now kept whatever the pattern says, and the README says
   that a host you stop replicating to leaves a pair to delete by hand.
 
+- A volume nobody wrote to is no longer snapshotted again. A snapshot or a
+  replication scheduled every minute wrote one identical subvolume per minute,
+  for as long as the volume stayed at rest, and replicating to two hosts wrote
+  two. The endpoint now compares the copy it just took with the previous
+  snapshot and deletes it when it carries nothing new, answering the name of
+  that previous snapshot. BTRFS cannot compare a live volume to a snapshot, so
+  the copy has to be taken before it can be judged; it is the only thing this
+  ever deletes, and it holds nothing that is not already elsewhere.
+
+  The answer of ``/VolumeDriver.Snapshot`` carries a new ``Created`` field, and
+  ``api.snapshot`` now returns the name and that flag. The scheduler needs it:
+  a replication that fails deletes the snapshot it took for the occasion, and
+  without the flag a network outage would have deleted a snapshot from an
+  earlier round. ``buttervolume snapshot`` still prints one name and nothing
+  else.
+
 - Sending a snapshot the remote host already holds no longer destroys the copy
   it has. ``buttervolume send`` sends whatever snapshot it is named, and naming
   the same one twice made it its own parent: the send succeeded, the remote

--- a/README.rst
+++ b/README.rst
@@ -441,6 +441,11 @@ The volumes are currently expected to live in ``/var/lib/buttervolume/volumes`` 
 the snapshot will be created in ``/var/lib/buttervolume/snapshots``, by appending the
 datetime to the name of the volume, separated with ``@``.
 
+A volume nobody wrote to since its last snapshot is not snapshotted again: the
+command prints the name of the existing snapshot, which is the one holding the
+state of the volume. So a snapshot scheduled every minute on a volume at rest
+costs one subvolume, not one per minute.
+
 
 List the snapshots
 ------------------
@@ -525,6 +530,11 @@ each send, named ``<volume>@<datetime>@<host>``, and nothing is asked of the
 remote host. So a snapshot whose trace is there is not sent a second time, and
 a copy deleted on the remote host behind Buttervolume's back goes unnoticed:
 delete the trace as well, and the next send carries the whole volume again.
+
+A replication scheduled on a volume at rest therefore costs nothing at all: the
+snapshot it would take is not taken, its trace says the remote host already has
+it, and nothing crosses the network. Replicating the same volume to two hosts
+every minute is a reasonable thing to schedule.
 
 
 ``<host>`` is the hostname or IP address of the remote host. The snapshot is

--- a/buttervolume/api.py
+++ b/buttervolume/api.py
@@ -113,8 +113,18 @@ def _get(urlpath):
 
 
 def snapshot(name, test=False):
-    """Snapshot a volume, and answer the name of the snapshot."""
-    return get_from(_post("/VolumeDriver.Snapshot", {"Name": name}, test), "Snapshot")
+    """Snapshot a volume, and answer its name and whether this call took it.
+
+    A volume nobody wrote to is not snapshotted again, so the name can be that
+    of a snapshot an earlier round took: a caller that deletes what it created
+    has to know which of the two it is holding. A call that failed answers
+    False twice, and has already said why.
+    """
+    resp = _post("/VolumeDriver.Snapshot", {"Name": name}, test)
+    snap = get_from(resp, "Snapshot")
+    # read a second time only once the first read said the answer carries no
+    # error, otherwise the error would be logged twice
+    return snap, bool(snap) and get_from(resp, "Created")
 
 
 def snapshots(name):

--- a/buttervolume/btrfs.py
+++ b/buttervolume/btrfs.py
@@ -122,6 +122,9 @@ class Subvolume:
         ``other_path`` is the parent: the difference is what this one adds to
         it. An incremental stream carrying nothing but its ``snapshot``
         header, a single line under ``receive --dump``, says nothing changed.
+        The lines are counted on the bytes and nothing is decoded: the dump
+        prints the value of an extended attribute exactly as it is, so a
+        volume holding a binary one would raise where it has to answer.
 
         Neither command goes through ``run_safe``: the send is piped into the
         dump, with the same four precautions as ``run_btrfs_send_receive``.
@@ -159,7 +162,7 @@ class Subvolume:
                 send_stderr_file.seek(0)
                 raise BtrfsError(
                     f"Comparing {self.path} to {other_path} timed out after "
-                    f"{COMPARE_TIMEOUT}s: {send_stderr_file.read().decode()}"
+                    f"{COMPARE_TIMEOUT}s: {send_stderr_file.read().decode(errors='replace')}"
                 ) from None
 
             if send_proc.returncode != 0 or dump_proc.returncode != 0:
@@ -167,10 +170,11 @@ class Subvolume:
                 raise BtrfsError(
                     f"Could not compare {self.path} to {other_path} "
                     f"(send: {send_proc.returncode}, dump: {dump_proc.returncode}): "
-                    f"{send_stderr_file.read().decode()} {dump_stderr.decode()}"
+                    f"{send_stderr_file.read().decode(errors='replace')} "
+                    f"{dump_stderr.decode(errors='replace')}"
                 )
 
-        return len(dump.decode().splitlines()) == 1
+        return len(dump.splitlines()) == 1
 
     def create(self, cow=False):
         """Create a new BTRFS subvolume"""

--- a/buttervolume/btrfs.py
+++ b/buttervolume/btrfs.py
@@ -2,9 +2,9 @@
 
 Every call goes through ``run_safe``: no shell, a timeout each caller states
 for itself, and any failure raised as a typed error rather than returned as
-something the caller cannot tell apart from a result. One path escapes it and
-needs the same care: ``run_btrfs_send_receive`` in ``plugin.py`` builds its own
-send and receive to pipe them over SSH.
+something the caller cannot tell apart from a result. Two paths escape it and
+need the same care, because they pipe a send into a receive: ``is_same_as``
+below, and ``run_btrfs_send_receive`` in ``plugin.py``, which sends over SSH.
 
 Nothing here knows what a volume is, which is why ``BtrfsError`` lives here
 rather than with the errors the API answers with.
@@ -12,7 +12,9 @@ rather than with the errors the API answers with.
 
 import contextlib
 import os
-from subprocess import CalledProcessError, TimeoutExpired
+import tempfile
+import time
+from subprocess import PIPE, CalledProcessError, Popen, TimeoutExpired
 from subprocess import run as _run
 
 # How long each command may legitimately take, in seconds
@@ -22,6 +24,7 @@ CREATE_TIMEOUT = 120
 DELETE_TIMEOUT = 300
 CHATTR_TIMEOUT = 10
 LABEL_TIMEOUT = 15
+COMPARE_TIMEOUT = 60
 
 
 class BtrfsError(Exception):
@@ -111,6 +114,63 @@ class Subvolume:
             cmd.append("-r")
         cmd.extend([self.path, target])
         return run_safe(cmd, timeout=SNAPSHOT_TIMEOUT, error=BtrfsSubvolumeError)
+
+    def is_same_as(self, other_path):
+        """Does this snapshot hold nothing the one at other_path does not?
+
+        Both are readonly subvolumes, which ``btrfs send`` requires, and
+        ``other_path`` is the parent: the difference is what this one adds to
+        it. An incremental stream carrying nothing but its ``snapshot``
+        header, a single line under ``receive --dump``, says nothing changed.
+
+        Neither command goes through ``run_safe``: the send is piped into the
+        dump, with the same four precautions as ``run_btrfs_send_receive``.
+        The whole dump is read into memory rather than line by line;
+        ``--no-data`` leaves the file contents out, but a volume where
+        millions of files changed would still produce as many lines, and
+        COMPARE_TIMEOUT is what bounds that. It also bounds the sync below,
+        which the send of a snapshot just taken needs to see committed.
+        """
+        run_safe(["btrfs", "filesystem", "sync", self.path], timeout=COMPARE_TIMEOUT)
+        send_cmd = ["btrfs", "send", "--no-data", "-p", other_path, self.path]
+        # the send stderr goes to a temporary file rather than a pipe: nobody
+        # can read that pipe while waiting for the dump side, and a verbose
+        # failure would fill it and deadlock both processes
+        with tempfile.TemporaryFile() as send_stderr_file:
+            send_proc = Popen(send_cmd, stdout=PIPE, stderr=send_stderr_file)
+            dump_proc = Popen(
+                ["btrfs", "receive", "--dump"], stdin=send_proc.stdout, stdout=PIPE, stderr=PIPE
+            )
+            send_proc.stdout.close()  # so the send gets a SIGPIPE if the dump exits
+
+            # one deadline for the two waits, so the comparison really is
+            # bounded by COMPARE_TIMEOUT and not by twice that
+            deadline = time.monotonic() + COMPARE_TIMEOUT
+            try:
+                dump, dump_stderr = dump_proc.communicate(timeout=COMPARE_TIMEOUT)
+                send_proc.wait(timeout=max(0.0, deadline - time.monotonic()))
+            except TimeoutExpired:
+                # killed, then reaped: a daemon that lives for months has no
+                # right to leave zombies behind
+                send_proc.kill()
+                dump_proc.kill()
+                send_proc.wait()
+                dump_proc.wait()
+                send_stderr_file.seek(0)
+                raise BtrfsError(
+                    f"Comparing {self.path} to {other_path} timed out after "
+                    f"{COMPARE_TIMEOUT}s: {send_stderr_file.read().decode()}"
+                ) from None
+
+            if send_proc.returncode != 0 or dump_proc.returncode != 0:
+                send_stderr_file.seek(0)
+                raise BtrfsError(
+                    f"Could not compare {self.path} to {other_path} "
+                    f"(send: {send_proc.returncode}, dump: {dump_proc.returncode}): "
+                    f"{send_stderr_file.read().decode()} {dump_stderr.decode()}"
+                )
+
+        return len(dump.decode().splitlines()) == 1
 
     def create(self, cow=False):
         """Create a new BTRFS subvolume"""

--- a/buttervolume/cli.py
+++ b/buttervolume/cli.py
@@ -52,7 +52,10 @@ log = logging.getLogger()
 
 
 def snapshot(args, test=False):
-    res = api.snapshot(args.name[0], test=test)
+    # only the name is printed: the command answers "which snapshot holds the
+    # state of this volume", and main() reads a False as an exit code of 1,
+    # which a tuple could never be
+    res, _ = api.snapshot(args.name[0], test=test)
     if res:
         print(res)
     return res

--- a/buttervolume/plugin.py
+++ b/buttervolume/plugin.py
@@ -17,6 +17,7 @@ import logging
 import os
 import subprocess
 import tempfile
+import threading
 import time
 from dataclasses import replace
 from datetime import datetime
@@ -434,6 +435,16 @@ def snapshot_send(req):
     return {"Err": ""}
 
 
+# One snapshot at a time. The endpoint below takes a copy, compares it with the
+# previous snapshot and deletes it when the two hold the same thing. Two calls
+# on the same volume, interleaved, would each compare against the copy of the
+# other, find it identical, and delete their own: the volume would come out of
+# the two calls with neither, while both answers named one. A single lock for
+# every volume is enough, since the scheduler runs its jobs one after the other
+# and the only other snapshot is the one somebody asks for.
+snapshotting = threading.Lock()
+
+
 @route("/VolumeDriver.Snapshot")
 def volume_snapshot(req):
     """Snapshot a volume in the SNAPSHOTS dir, unless it holds nothing new.
@@ -448,41 +459,43 @@ def volume_snapshot(req):
     name = req["Name"]
     volume = existing_volume(name)
 
-    timestamped = new_snapshot_name(name)
-    path = snapshotpath(timestamped)
-    volume.snapshot(path, readonly=True)
+    with snapshotting:
+        timestamped = new_snapshot_name(name)
+        path = snapshotpath(timestamped)
+        volume.snapshot(path, readonly=True)
 
-    # BTRFS cannot compare a live volume to a snapshot, since a send needs a
-    # readonly subvolume, so the comparison happens after the fact: the copy
-    # just taken is deleted when it holds nothing the previous one does not.
-    # The traces of the sends are left out: their content is that of their own
-    # snapshot, but naming one here would have the next send refuse it.
-    previous = max(
-        (
-            s
-            for s in parsed(os.listdir(SNAPSHOTS_PATH))
-            if s.volume == name and not s.host and str(s) != timestamped
-        ),
-        key=str,
-        default=None,
-    )
-    if previous:
-        try:
-            if btrfs.Subvolume(path).is_same_as(snapshotpath(str(previous))):
-                btrfs.Subvolume(path).delete()
-                log.info("%s has not changed since %s", name, previous)
-                return {"Err": "", "Snapshot": str(previous), "Created": False}
-        except BtrfsError as e:
-            # neither a comparison we could not make nor a deletion that failed
-            # is a reason to lose a snapshot: the copy is kept, and answered as
-            # the one this call took
-            log.warning(
-                "Keeping %s, which could not be compared with %s or dropped: %s",
-                timestamped,
-                previous,
-                e,
-            )
-    return {"Err": "", "Snapshot": timestamped, "Created": True}
+        # BTRFS cannot compare a live volume to a snapshot, since a send needs
+        # a readonly subvolume, so the comparison happens after the fact: the
+        # copy just taken is deleted when it holds nothing the previous one
+        # does not. The traces of the sends are left out: their content is that
+        # of their own snapshot, but naming one here would have the next send
+        # refuse it.
+        previous = max(
+            (
+                s
+                for s in parsed(os.listdir(SNAPSHOTS_PATH))
+                if s.volume == name and not s.host and str(s) != timestamped
+            ),
+            key=str,
+            default=None,
+        )
+        if previous:
+            try:
+                if btrfs.Subvolume(path).is_same_as(snapshotpath(str(previous))):
+                    btrfs.Subvolume(path).delete()
+                    log.info("%s has not changed since %s", name, previous)
+                    return {"Err": "", "Snapshot": str(previous), "Created": False}
+            except BtrfsError as e:
+                # neither a comparison we could not make nor a deletion that
+                # failed is a reason to lose a snapshot: the copy is kept, and
+                # answered as the one this call took
+                log.warning(
+                    "Keeping %s, which could not be compared with %s or dropped: %s",
+                    timestamped,
+                    previous,
+                    e,
+                )
+        return {"Err": "", "Snapshot": timestamped, "Created": True}
 
 
 @route("/VolumeDriver.Snapshot.List", "GET")

--- a/buttervolume/plugin.py
+++ b/buttervolume/plugin.py
@@ -473,8 +473,15 @@ def volume_snapshot(req):
                 log.info("%s has not changed since %s", name, previous)
                 return {"Err": "", "Snapshot": str(previous), "Created": False}
         except BtrfsError as e:
-            # a comparison we could not make is no reason to lose a snapshot
-            log.warning("Could not tell whether %s changed since %s: %s", name, previous, e)
+            # neither a comparison we could not make nor a deletion that failed
+            # is a reason to lose a snapshot: the copy is kept, and answered as
+            # the one this call took
+            log.warning(
+                "Keeping %s, which could not be compared with %s or dropped: %s",
+                timestamped,
+                previous,
+                e,
+            )
     return {"Err": "", "Snapshot": timestamped, "Created": True}
 
 

--- a/buttervolume/plugin.py
+++ b/buttervolume/plugin.py
@@ -49,6 +49,7 @@ from buttervolume.config import (
 from buttervolume.names import (
     Snapshot,
     new_snapshot,
+    parsed,
     sent_snapshots,
     snapshots_of,
     validate_hostname,
@@ -435,13 +436,46 @@ def snapshot_send(req):
 
 @route("/VolumeDriver.Snapshot")
 def volume_snapshot(req):
-    """snapshot a volume in the SNAPSHOTS dir"""
+    """Snapshot a volume in the SNAPSHOTS dir, unless it holds nothing new.
+
+    The answer names the snapshot that holds the state of the volume, and says
+    in "Created" whether this call is the one that took it. A volume nobody
+    wrote to gives the name of the previous snapshot and takes none, which is
+    what keeps a replication scheduled every minute from filling the disk with
+    identical copies. A caller that deletes what it created has to read that
+    flag: the name alone no longer says whose snapshot it is.
+    """
     name = req["Name"]
     volume = existing_volume(name)
 
     timestamped = new_snapshot_name(name)
-    volume.snapshot(snapshotpath(timestamped), readonly=True)
-    return {"Err": "", "Snapshot": timestamped}
+    path = snapshotpath(timestamped)
+    volume.snapshot(path, readonly=True)
+
+    # BTRFS cannot compare a live volume to a snapshot, since a send needs a
+    # readonly subvolume, so the comparison happens after the fact: the copy
+    # just taken is deleted when it holds nothing the previous one does not.
+    # The traces of the sends are left out: their content is that of their own
+    # snapshot, but naming one here would have the next send refuse it.
+    previous = max(
+        (
+            s
+            for s in parsed(os.listdir(SNAPSHOTS_PATH))
+            if s.volume == name and not s.host and str(s) != timestamped
+        ),
+        key=str,
+        default=None,
+    )
+    if previous:
+        try:
+            if btrfs.Subvolume(path).is_same_as(snapshotpath(str(previous))):
+                btrfs.Subvolume(path).delete()
+                log.info("%s has not changed since %s", name, previous)
+                return {"Err": "", "Snapshot": str(previous), "Created": False}
+        except BtrfsError as e:
+            # a comparison we could not make is no reason to lose a snapshot
+            log.warning("Could not tell whether %s changed since %s: %s", name, previous, e)
+    return {"Err": "", "Snapshot": timestamped, "Created": True}
 
 
 @route("/VolumeDriver.Snapshot.List", "GET")

--- a/buttervolume/scheduler.py
+++ b/buttervolume/scheduler.py
@@ -86,11 +86,14 @@ def run_job(job, name, test=False):
 @run_job.register
 def run_snapshot(job: Snapshot, name, test=False):
     log.info("Starting scheduled snapshot of %s", name)
-    snap = api.snapshot(name, test=test)
+    snap, created = api.snapshot(name, test=test)
     if not snap:
         log.info("Could not snapshot %s", name)
         return False
-    log.info("Successfully snapshotted to %s", snap)
+    if created:
+        log.info("Successfully snapshotted to %s", snap)
+    else:
+        log.info("%s has not changed since %s, no new snapshot", name, snap)
     return True
 
 
@@ -101,23 +104,26 @@ def run_replicate(job: Replicate, name, test=False):
         return False
     log.info("Starting scheduled replication of %s", name)
     snap = None
+    created = False
     try:
         ReplicationInProgress.add(name)
-        snap = api.snapshot(name, test=test)
+        snap, created = api.snapshot(name, test=test)
         if not snap:
             log.info("Could not snapshot %s", name)
             return False
-        log.info("Successfully snapshotted to %s", snap)
+        log.info("Replicating %s", snap)
         if not api.send(snap, job.host, test=test):
-            # the same road as an exception: the error is already logged,
-            # and the snapshot taken for this replication has no reason to stay
+            # the same road as an exception: the error is already logged, and
+            # a snapshot taken for this replication has no reason to stay
             raise ReplicationError(f"Could not send {snap} to {job.host}")
         log.info("Successfully replicated %s to %s", name, snap)
         return True
     except Exception as e:
         log.warning("Replication failed: %s", e)
-        # remove snapshot that was created for the failed replication
-        if snap:
+        # remove the snapshot this round created for the replication, and
+        # only that one: an unchanged volume gives back the snapshot of an
+        # earlier round, which a failure here is no reason to delete
+        if snap and created:
             if api.remove(snap, test=test):
                 log.info("Removed snapshot %s for failed replication", snap)
             else:
@@ -158,14 +164,15 @@ def run_synchronize(job: Synchronize, name, test=False):
     log.info("Starting scheduled synchronization of %s", name)
     hosts = list(job.hosts)
     # do a snapshot to save state before pulling data
-    snap = api.snapshot(name, test=test)
+    snap, _ = api.snapshot(name, test=test)
     if not snap:
         log.info("Could not snapshot %s", name)
         return False
     # said out loud, like the two other jobs that take one: this is the
     # snapshot a pull stopped halfway is recovered from, and an administrator
-    # who has to go back to it needs to read its name somewhere
-    log.info("Successfully snapshotted to %s", snap)
+    # who has to go back to it needs to read its name somewhere. It can be the
+    # one an earlier round took, when nothing was written since
+    log.info("%s can be recovered from the snapshot %s", name, snap)
     if api.sync([name], hosts, test=test):
         log.debug("End of %s synchronization from %s", name, hosts)
     else:

--- a/test.py
+++ b/test.py
@@ -346,6 +346,11 @@ class TestCase(unittest.TestCase):
         with open(join(path, "foobar"), "w") as f:
             f.write("foobar")
 
+    def write_a_byte(self, name):
+        """Make the volume differ from its latest snapshot, and nothing more"""
+        with open(join(VOLUMES_PATH, name, "foobar"), "a") as f:
+            f.write(".")
+
     def test(self):
         """first basic scenario"""
         resp = jsonloads(self.app.post("/VolumeDriver.List", "{}").body)
@@ -585,6 +590,123 @@ class TestCase(unittest.TestCase):
         with open(join(path, "foobar")) as x, open(join(snapshot, "foobar")) as y:
             self.assertEqual(x.read(), y.read())
 
+    def test_a_snapshot_says_whether_the_volume_changed_since_another_one(self):
+        """What is compared is two readonly subvolumes, never the live volume"""
+        name = PREFIX_TEST_VOLUME + uuid.uuid4().hex
+        self.create_a_volume_with_a_file(name)
+        volume = btrfs.Subvolume(join(VOLUMES_PATH, name))
+        paths = [join(SNAPSHOTS_PATH, f"{name}@2026-01-0{i}T00:00:00.000000") for i in range(1, 4)]
+        volume.snapshot(paths[0], readonly=True)
+        volume.snapshot(paths[1], readonly=True)
+        self.assertTrue(btrfs.Subvolume(paths[1]).is_same_as(paths[0]))
+
+        self.write_a_byte(name)
+        volume.snapshot(paths[2], readonly=True)
+        self.assertFalse(btrfs.Subvolume(paths[2]).is_same_as(paths[1]))
+
+    def test_an_unchanged_volume_is_not_snapshotted_again(self):
+        """The answer names the snapshot that holds the state, and says who took it"""
+        name = PREFIX_TEST_VOLUME + uuid.uuid4().hex
+        self.create_a_volume_with_a_file(name)
+        first = jsonloads(self.app.post("/VolumeDriver.Snapshot", json.dumps({"Name": name})).body)
+        second = jsonloads(self.app.post("/VolumeDriver.Snapshot", json.dumps({"Name": name})).body)
+        self.assertTrue(first["Created"])
+        self.assertEqual(second["Snapshot"], first["Snapshot"])
+        self.assertFalse(second["Created"])
+        # and the copy taken for the comparison is gone from the disk
+        self.assertEqual(
+            [s for s in os.listdir(SNAPSHOTS_PATH) if s.startswith(name + "@")],
+            [first["Snapshot"]],
+        )
+
+    def test_a_volume_written_to_is_snapshotted_again(self):
+        name = PREFIX_TEST_VOLUME + uuid.uuid4().hex
+        self.create_a_volume_with_a_file(name)
+        first = jsonloads(self.app.post("/VolumeDriver.Snapshot", json.dumps({"Name": name})).body)
+        self.write_a_byte(name)
+        second = jsonloads(self.app.post("/VolumeDriver.Snapshot", json.dumps({"Name": name})).body)
+        self.assertTrue(second["Created"])
+        self.assertNotEqual(second["Snapshot"], first["Snapshot"])
+        self.assertEqual(
+            len([s for s in os.listdir(SNAPSHOTS_PATH) if s.startswith(name + "@")]), 2
+        )
+
+    def test_the_snapshot_of_an_unchanged_volume_still_restores(self):
+        """The name given back is a snapshot, not a bookkeeping entry"""
+        name = PREFIX_TEST_VOLUME + uuid.uuid4().hex
+        path = join(VOLUMES_PATH, name)
+        self.create_a_volume_with_a_file(name)
+        self.app.post("/VolumeDriver.Snapshot", json.dumps({"Name": name}))
+        again = jsonloads(self.app.post("/VolumeDriver.Snapshot", json.dumps({"Name": name})).body)
+        with open(join(path, "foobar"), "w") as f:
+            f.write("modified foobar")
+
+        resp = jsonloads(
+            self.app.post(
+                "/VolumeDriver.Snapshot.Restore", json.dumps({"Name": again["Snapshot"]})
+            ).body
+        )
+        self.assertEqual(resp["Err"], "")
+        with open(join(path, "foobar")) as f:
+            self.assertEqual(f.read(), "foobar")
+
+    def test_a_failed_replication_keeps_a_snapshot_it_did_not_create(self):
+        """Only the snapshot of this round goes, and an unchanged volume gave none"""
+        name = PREFIX_TEST_VOLUME + uuid.uuid4().hex
+        self.create_a_volume_with_a_file(name)
+        existing = jsonloads(
+            self.app.post("/VolumeDriver.Snapshot", json.dumps({"Name": name})).body
+        )["Snapshot"]
+        self.app.post(
+            "/VolumeDriver.Schedule",
+            json.dumps({"Name": name, "Action": "replicate:localhost", "Timer": 1}),
+        )
+        with patch("buttervolume.api.send") as mock_send:
+            mock_send.side_effect = Exception("replication failed")
+            runjobs(SCHEDULE, True, last_runs=LAST_RUNS)
+        mock_send.assert_called_once()
+        self.assertEqual(
+            [s for s in os.listdir(SNAPSHOTS_PATH) if s.startswith(name + "@")], [existing]
+        )
+        # unschedule
+        self.app.post(
+            "/VolumeDriver.Schedule",
+            json.dumps({"Name": name, "Action": "replicate:localhost", "Timer": 0}),
+        )
+
+    @unittest.skipIf(
+        os.environ.get("BUTTERVOLUME_LOCAL_TEST"), "SSH not available in local test mode"
+    )
+    def test_replicating_a_volume_at_rest_twice_transfers_nothing_the_second_time(self):
+        """Two rounds on a volume nobody wrote to leave one snapshot and one copy"""
+        name = PREFIX_TEST_VOLUME + uuid.uuid4().hex
+        self.create_a_volume_with_a_file(name)
+        with open(SCHEDULE, "w") as f:
+            f.write(f"{name},replicate:localhost,60,True\n")
+        for _ in range(2):
+            write_last_runs(
+                LAST_RUNS,
+                {"replicate:localhost": {name: datetime.now() - timedelta(days=1)}},
+            )
+            runjobs(config=SCHEDULE, test=True, last_runs=LAST_RUNS)
+
+        # the second round reported a success, so its date was written down
+        last = read_last_runs(LAST_RUNS)["replicate:localhost"][name]
+        self.assertGreater(last, datetime.now() - timedelta(minutes=1))
+        # one snapshot and its trace, and a single copy on the other side
+        self.assertEqual(
+            len([s for s in os.listdir(SNAPSHOTS_PATH) if s.startswith(name + "@")]), 2
+        )
+        remote = [s for s in os.listdir(TEST_REMOTE_PATH) if s.startswith(name + "@")]
+        self.assertEqual(len(remote), 1)
+
+        # restored, because counting the copies proves nothing: one destroyed
+        # and sent again counts exactly like one left alone
+        target = PREFIX_TEST_VOLUME + uuid.uuid4().hex
+        btrfs.Subvolume(join(TEST_REMOTE_PATH, remote[0])).snapshot(join(VOLUMES_PATH, target))
+        with open(join(VOLUMES_PATH, target, "foobar")) as f:
+            self.assertEqual(f.read(), "foobar")
+
     def test_snapshots(self):
         """Check we can list snapshots"""
         # create two volumes with a file
@@ -592,13 +714,16 @@ class TestCase(unittest.TestCase):
         self.create_a_volume_with_a_file(name)
         name2 = PREFIX_TEST_VOLUME + uuid.uuid4().hex
         self.create_a_volume_with_a_file(name2)
-        # snapshot each volume twice
+        # snapshot each volume twice, writing in between so that the second
+        # snapshot is really taken: an unchanged volume gives back the first
         resp = self.app.post("/VolumeDriver.Snapshot", json.dumps({"Name": name}))
         snap1 = json.loads(resp.body.decode())["Snapshot"]
+        self.write_a_byte(name)
         resp = self.app.post("/VolumeDriver.Snapshot", json.dumps({"Name": name}))
         snap2 = json.loads(resp.body.decode())["Snapshot"]
         resp = self.app.post("/VolumeDriver.Snapshot", json.dumps({"Name": name2}))
         snap3 = json.loads(resp.body.decode())["Snapshot"]
+        self.write_a_byte(name2)
         resp = self.app.post("/VolumeDriver.Snapshot", json.dumps({"Name": name2}))
         snap4 = json.loads(resp.body.decode())["Snapshot"]
         # list all the snapshots
@@ -665,6 +790,9 @@ class TestCase(unittest.TestCase):
         self.assertEqual(len(schedule), 1)
         # simulate the last snapshot is 1 day in the past
         write_last_runs(LAST_RUNS, {"snapshot": {name2: datetime.now() - timedelta(days=1)}})
+        # and write in the volume, otherwise the round below takes no snapshot
+        # at all: an unchanged volume is not snapshotted again
+        self.write_a_byte(name2)
         # run the scheduler jobs and check we only have one more snapshot
         runjobs(SCHEDULE, test=True, last_runs=LAST_RUNS)
         self.assertEqual(

--- a/test.py
+++ b/test.py
@@ -604,6 +604,19 @@ class TestCase(unittest.TestCase):
         volume.snapshot(paths[2], readonly=True)
         self.assertFalse(btrfs.Subvolume(paths[2]).is_same_as(paths[1]))
 
+    def test_an_extended_attribute_nobody_can_read_as_text_is_still_compared(self):
+        """receive --dump writes the value of an attribute exactly as it is"""
+        name = PREFIX_TEST_VOLUME + uuid.uuid4().hex
+        self.create_a_volume_with_a_file(name)
+        volume = btrfs.Subvolume(join(VOLUMES_PATH, name))
+        before = join(SNAPSHOTS_PATH, f"{name}@2026-02-01T00:00:00.000000")
+        after = join(SNAPSHOTS_PATH, f"{name}@2026-02-02T00:00:00.000000")
+        volume.snapshot(before, readonly=True)
+        # the kind of thing a file server writes next to a file it stores
+        os.setxattr(join(VOLUMES_PATH, name, "foobar"), "user.binary", b"\xff\xfe\x00")
+        volume.snapshot(after, readonly=True)
+        self.assertFalse(btrfs.Subvolume(after).is_same_as(before))
+
     def test_an_unchanged_volume_is_not_snapshotted_again(self):
         """The answer names the snapshot that holds the state, and says who took it"""
         name = PREFIX_TEST_VOLUME + uuid.uuid4().hex

--- a/test.py
+++ b/test.py
@@ -617,6 +617,32 @@ class TestCase(unittest.TestCase):
         volume.snapshot(after, readonly=True)
         self.assertFalse(btrfs.Subvolume(after).is_same_as(before))
 
+    def test_two_snapshots_of_the_same_volume_at_once_leave_one(self):
+        """Each call deletes the copy it took, never the copy of the other one"""
+        name = PREFIX_TEST_VOLUME + uuid.uuid4().hex
+        self.create_a_volume_with_a_file(name)
+        answers = []
+
+        def take_one():
+            resp = self.app.post("/VolumeDriver.Snapshot", json.dumps({"Name": name}))
+            answers.append(jsonloads(resp.body))
+
+        threads = [threading.Thread(target=take_one) for _ in range(2)]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join()
+
+        # a volume nobody wrote to comes out of the two calls with a single
+        # snapshot, and neither answer names one that is no longer there
+        self.assertEqual(len(answers), 2)
+        for answer in answers:
+            self.assertEqual(answer["Err"], "")
+            self.assertTrue(os.path.exists(join(SNAPSHOTS_PATH, answer["Snapshot"])))
+        self.assertEqual(
+            len([s for s in os.listdir(SNAPSHOTS_PATH) if s.startswith(name + "@")]), 1
+        )
+
     def test_an_unchanged_volume_is_not_snapshotted_again(self):
         """The answer names the snapshot that holds the state, and says who took it"""
         name = PREFIX_TEST_VOLUME + uuid.uuid4().hex


### PR DESCRIPTION
This work needed #111, which is now in `master`. Without it, the second
replication of a volume at rest names a snapshot the remote host already holds,
and the fallback of `snapshot_send` deletes the good remote copy.

`volume_snapshot` always created `volume@now`. A `snapshot` scheduled every
minute on a volume at rest wrote one identical subvolume per minute, and
`replicate:hostA` plus `replicate:hostB` wrote two, which is the case ticket #68
reports.

BTRFS imposes the order. `btrfs send` needs a readonly subvolume, so a live
volume cannot be compared to a snapshot: the copy is taken first, compared to
the previous snapshot with `send --no-data -p` piped into `receive --dump`, and
deleted when the stream carries nothing but its header. It is a deletion, which
rubs against "Destruction stays deliberate" in AGENTS.md, and the answer is that
the thing deleted is the one this very call created and holds nothing that is
not already in the snapshot named back. A comparison that fails keeps the copy.

The comparison lives in `btrfs.py` and pipes two processes without a shell, with
the four precautions `run_btrfs_send_receive` documents: the sync first, the
send stderr in a temporary file rather than a pipe nobody drains, the
`stdout.close()` so the send gets a SIGPIPE, and one deadline for both waits
with the two processes killed *and reaped* on expiry. The dump is read whole
rather than two lines at a time; `--no-data` leaves the contents out, and
`COMPARE_TIMEOUT` bounds the volume where millions of files changed.

**`Created` is part of the subject, not an extra.** `run_replicate` deletes the
snapshot it took when the replication fails. The name it now holds can come from
an earlier round, so without the flag a network outage would delete a snapshot
this round never created: a data loss introduced by this change.
`/VolumeDriver.Snapshot` answers the flag, `api.snapshot` returns the pair, the
scheduler reads it, and `buttervolume snapshot` still prints one name (returning
the pair would break `main()`, which reads `is False` as an exit code of 1).

Two existing tests took two snapshots of a volume without writing in between and
counted on both existing. They write a byte now, which leaves what they were
checking intact.

A review of this branch found three things, fixed in the three commits that
follow the first one. The comparison decoded the dump of `btrfs receive`, which
writes the value of an extended attribute exactly as it is: a volume holding a
binary one raised a `UnicodeDecodeError`, which is not a `BtrfsError`, so it
went past the guard that keeps a comparison we could not make from losing a
snapshot. The lines are counted on the bytes now. Two calls on the same volume
at once each compared their copy with the copy of the other, found it
identical, and deleted their own, leaving the volume with neither while both
answers named one: one lock answers that. And the deletion sat inside the same
`try` as the comparison, so a failed deletion was reported as a comparison
nobody could make.

Verified: `88 passed, 6 skipped` under `test_local.sh`, `94 passed` under
`./test.sh`, including the two new tests that **restore** the remote copy. And
the scenario the work is for: ten scheduled rounds on a volume at rest give one
local snapshot, one trace, one remote copy, nine "has not changed since" and
nine "nothing to send".
