### PR TITLE
Receive a snapshot from a host that has it

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,23 @@ CHANGELOG
 3.13 (unreleased)
 *****************
 
+- Buttervolume can now receive a snapshot from another host, where it could
+  only send one. ``buttervolume receive <host> <volume>`` fetches the most
+  recent snapshot that host keeps of that volume, incrementally when the two
+  still share an older one, and prints its name. It restores nothing: which
+  snapshot becomes the volume stays a separate decision.
+
+  A host that keeps no snapshot of the volume and a host that could not answer
+  are two different answers. The listing raises when ssh fails or takes too
+  long, so an empty answer only ever means a host that answered and holds
+  nothing. Reading silence as "there is nothing over there" is how the good
+  copy of a volume gets replaced by an older one.
+
+  The trace ``<volume>@<datetime>@<host>`` is written after a receive as it is
+  after a send, since a snapshot that just arrived from a host is a snapshot
+  that host holds. Without it, the first send back would carry the whole
+  volume again.
+
 - A purge no longer deletes what a replication needs. The trace of the last
   send to a host is a snapshot like any other, with a date the purge could
   read, so a retention pattern would delete it along with the snapshot it was

--- a/README.rst
+++ b/README.rst
@@ -425,6 +425,7 @@ When buttervolume is installed, it provides a command line tool
     restore             Restore a snapshot (optionally to a different volume)
     clone               Clone a volume as new volume
     send                Send a snapshot to another host
+    receive             Receive from another host its last snapshot of a volume
     sync                Synchronise a volume from a remote host volume
     rm                  Delete a snapshot
     purge               Purge old snapshot using a purge pattern
@@ -525,10 +526,12 @@ consuming a lot of bandwith or disk space::
 to live in ``/var/lib/buttervolume/snapshots`` and is replicated to the same path on
 the remote host.
 
-What the remote host already holds is read from the trace kept locally after
-each send, named ``<volume>@<datetime>@<host>``, and nothing is asked of the
-remote host. So a snapshot whose trace is there is not sent a second time, and
-a copy deleted on the remote host behind Buttervolume's back goes unnoticed:
+What the remote host already holds is read from the trace kept locally,
+named ``<volume>@<datetime>@<host>``, and nothing is asked of the remote host.
+That trace is written after each send, and after each receive from that host,
+since a snapshot that has just arrived from a host is a snapshot that host
+holds. So a snapshot whose trace is there is not sent a second time, and a
+copy deleted on the remote host behind Buttervolume's back goes unnoticed:
 delete the trace as well, and the next send carries the whole volume again.
 
 A replication scheduled on a volume at rest therefore costs nothing at all: the
@@ -551,6 +554,39 @@ included in the plugin.
 The default SSH_PORT of the ssh server included in the plugin is **1122**. You can
 change it with `docker plugin set ccomb/buttervolume SSH_PORT=<PORT>` before
 enabling the plugin.
+
+Receive a snapshot from another host
+------------------------------------
+
+The other direction, for a host that wants back what another one holds::
+
+    buttervolume receive <host> <volume>
+
+It names a **volume**, where ``send`` names a snapshot: whoever receives does
+not know what the other host has, which is precisely the question this asks.
+The most recent snapshot that host keeps of that volume is fetched into
+``/var/lib/buttervolume/snapshots``, and its name is printed. Only the
+difference crosses the network when the two hosts still share an older
+snapshot to build on.
+
+The command **does not restore anything**. It brings a snapshot over, and
+which snapshot becomes the volume stays a separate, explicit decision::
+
+    buttervolume receive node2 www
+    buttervolume restore www
+
+A host that keeps no snapshot of that volume and a host that could not answer
+are two different answers, and never the same one. An unreachable host, a
+refused connection, an ssh that takes too long: each is reported as the error
+it is. Only a host that answered and holds nothing is reported as holding
+nothing. Reading silence as "there is nothing over there" is how the good copy
+of a volume gets replaced by an older one.
+
+A snapshot carries the moment it was taken on the machine that took it, and
+"the most recent" is read from that name. A host whose clock runs ahead
+therefore passes its copy off as the most recent one, so the hosts replicating
+to each other should agree on the time.
+
 
 Synchronize a volume from another host volume
 ---------------------------------------------

--- a/buttervolume/api.py
+++ b/buttervolume/api.py
@@ -155,6 +155,16 @@ def send(snapshot, host, test=False):
     return get_from(_post("/VolumeDriver.Snapshot.Send", payload, test), "") is not False
 
 
+def receive(volume, host, test=False):
+    """Fetch the last snapshot another host has of a volume, and answer its name."""
+    payload = {"Name": volume, "Host": host}
+    if test:
+        # the plugin reads it to fetch the snapshot from next door rather than
+        # from another machine
+        payload["Test"] = True
+    return get_from(_post("/VolumeDriver.Snapshot.Receive", payload, test), "Snapshot")
+
+
 def sync(volumes, hosts, test=False):
     """Pull these volumes back from these hosts, and answer whether it went."""
     payload = {"Volumes": volumes, "Hosts": hosts}

--- a/buttervolume/cli.py
+++ b/buttervolume/cli.py
@@ -186,6 +186,13 @@ def send(args, test=False):
     return api.send(args.snapshot[0], args.host[0], test=test)
 
 
+def receive(args, test=False):
+    res = api.receive(args.volume[0], args.host[0], test=test)
+    if res:
+        print(res)
+    return res
+
+
 def sync(args, test=False):
     return api.sync(args.volumes, args.hosts, test=test)
 
@@ -356,6 +363,16 @@ def main():
     parser_send.add_argument("host", metavar="host", nargs=1, help="Host to send the snapshot to")
     parser_send.add_argument("snapshot", metavar="snapshot", nargs=1, help="Snapshot to send")
 
+    parser_receive = subparsers.add_parser(
+        "receive", help="Receive the last snapshot another host has of a volume"
+    )
+    parser_receive.add_argument(
+        "host", metavar="host", nargs=1, help="Host to receive the snapshot from"
+    )
+    parser_receive.add_argument(
+        "volume", metavar="volume", nargs=1, help="Volume whose snapshot to receive"
+    )
+
     parser_sync = subparsers.add_parser("sync", help="Sync a volume from other host(s)")
     parser_sync.add_argument("volumes", metavar="volumes", nargs=1, help="Volumes to sync (1 max)")
     parser_sync.add_argument(
@@ -423,6 +440,7 @@ def main():
     parser_restore.set_defaults(func=restore)
     parser_clone.set_defaults(func=clone)
     parser_send.set_defaults(func=send)
+    parser_receive.set_defaults(func=receive)
     parser_sync.set_defaults(func=sync)
     parser_remove.set_defaults(func=remove)
     parser_purge.set_defaults(func=purge)

--- a/buttervolume/config.py
+++ b/buttervolume/config.py
@@ -60,11 +60,15 @@ if not os.path.exists(USOCKET):
             continue  # Try next driver name
 
 TIMER = int(getconfig(config, "TIMER", 60))
-# How long each external command may legitimately take, in seconds. These two
+# How long each external command may legitimately take, in seconds. These three
 # are not read from the configuration file, but they are delays like the next
 # one and are read next to it.
 SYNC_TIMEOUT = 30
 RSYNC_TIMEOUT = 600
+# How long a remote host has to answer a question that is not a transfer, such
+# as saying which snapshots it keeps. Not SEND_TIMEOUT: waiting ten minutes for
+# a listing would hold up whoever asked for it just as long.
+REMOTE_TIMEOUT = 30
 # The send crosses the network, so its limit is configurable like the rest
 SEND_TIMEOUT = int(getconfig(config, "SEND_TIMEOUT", 600))
 DTFORMAT = getconfig(config, "DTFORMAT", "%Y-%m-%dT%H:%M:%S.%f")

--- a/buttervolume/names.py
+++ b/buttervolume/names.py
@@ -183,8 +183,8 @@ def _taken_snapshots(volume, names):
     itself and would pass for the most recent one.
 
     Every name of this volume is read, and one that cannot be read raises
-    rather than being dropped. These names come from a listing, and a listing
-    we could not read must never be answered as a volume with no snapshot.
+    rather than being dropped. These names come from another machine, and a
+    listing we could not read must never be answered as a host with nothing.
     """
     return [s for s in map(Snapshot.parse, snapshots_of(volume, names)) if not s.host]
 
@@ -204,7 +204,12 @@ def snapshot_to_fetch(volume, remote_names, local_names):
     remote = _taken_snapshots(volume, remote_names)
     if not remote:
         return None
-    local = {str(s) for s in _taken_snapshots(volume, local_names)}
+    # what we hold is read as plain names, none of which has to make sense: a
+    # name saying the same thing as one over there is the same snapshot, and a
+    # name we could not have written says the same thing as none of them. So a
+    # stray file in our own directory stops nothing, the way it stops nothing
+    # anywhere else this directory is read.
+    held = set(local_names)
     # never the one being fetched, which cannot be its own parent
-    common = [s for s in remote[:-1] if str(s) in local]
+    common = [s for s in remote[:-1] if str(s) in held]
     return remote[-1], (common[-1] if common else None)

--- a/buttervolume/names.py
+++ b/buttervolume/names.py
@@ -173,3 +173,38 @@ def sent_snapshots(volume, host, names):
         (s for s in parsed(names) if s.volume == volume and s.host == host),
         key=str,
     )
+
+
+def _taken_snapshots(volume, names):
+    """The snapshots taken of this volume among these names, the traces left out.
+
+    A trace of a send is named after the snapshot it was made from, plus the
+    target, so `www@2026-08-26T10:00:00.000000@node3` sorts after the snapshot
+    itself and would pass for the most recent one.
+
+    Every name of this volume is read, and one that cannot be read raises
+    rather than being dropped. These names come from a listing, and a listing
+    we could not read must never be answered as a volume with no snapshot.
+    """
+    return [s for s in map(Snapshot.parse, snapshots_of(volume, names)) if not s.host]
+
+
+def snapshot_to_fetch(volume, remote_names, local_names):
+    """What to ask that host for, and the parent both sides already hold.
+
+    The pair `(snapshot, parent)`, or None when the host holds no snapshot of
+    this volume. The parent is the most recent older snapshot the two sides
+    have in common, which is what an incremental transfer is built on; None
+    when they have none, and then the whole volume has to come over.
+
+    The parent is read from the two listings rather than from the trace of a
+    send, which says what we once sent there. The question here is what that
+    host has now, and it has just been asked.
+    """
+    remote = _taken_snapshots(volume, remote_names)
+    if not remote:
+        return None
+    local = {str(s) for s in _taken_snapshots(volume, local_names)}
+    # never the one being fetched, which cannot be its own parent
+    common = [s for s in remote[:-1] if str(s) in local]
+    return remote[-1], (common[-1] if common else None)

--- a/buttervolume/plugin.py
+++ b/buttervolume/plugin.py
@@ -53,6 +53,7 @@ from buttervolume.names import (
     new_snapshot,
     parsed,
     sent_snapshots,
+    snapshot_to_fetch,
     snapshots_of,
     validate_hostname,
     validate_snapshot_name,
@@ -205,6 +206,79 @@ def run_btrfs_send_receive(
             )
 
     return receive_stdout.decode()
+
+
+def run_btrfs_receive(remote_host, remote_snapshot_path, remote_parent_path=None, port="1122"):
+    """Securely run btrfs send/receive over SSH, the other way round.
+
+    `remote_parent_path` is a path on the other machine, not here: it goes
+    into the command that host runs. Its counterpart on the send side is a
+    local path, and on a test bench where the two directories sit on the same
+    filesystem, one passed for the other goes unnoticed.
+
+    Nothing is synced first, unlike the send side, which syncs because the
+    snapshot it is about to send was just taken here. Nothing was written here
+    now, and the snapshot over there was committed long ago.
+    """
+    validate_hostname(remote_host)
+
+    # Build the send command the remote host will run
+    send_cmd = ["btrfs", "send"]
+    if remote_parent_path:
+        send_cmd.extend(["-p", remote_parent_path])
+    send_cmd.append(remote_snapshot_path)
+
+    ssh_cmd = [
+        "ssh",
+        "-p",
+        port,
+        "-o",
+        "StrictHostKeyChecking=no",
+        remote_host,
+        " ".join(send_cmd),
+    ]
+    receive_cmd = ["btrfs", "receive", SNAPSHOTS_PATH]
+
+    # Execute ssh send | receive using subprocess.
+    # The stderr of the sending side goes to a temporary file rather than a
+    # pipe, for the same reason as on the send side: nobody can read that pipe
+    # while waiting for the receive side, and a verbose failure would fill it
+    # and deadlock both processes.
+    with tempfile.TemporaryFile() as send_stderr_file:
+        send_proc = subprocess.Popen(ssh_cmd, stdout=subprocess.PIPE, stderr=send_stderr_file)
+        receive_proc = subprocess.Popen(
+            receive_cmd, stdin=send_proc.stdout, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+        )
+
+        send_proc.stdout.close()  # Allow send_proc to receive a SIGPIPE if receive_proc exits
+
+        # one deadline for the two waits, so the whole transfer really is
+        # bounded by SEND_TIMEOUT and not by twice that
+        deadline = time.monotonic() + SEND_TIMEOUT
+        try:
+            receive_stdout, receive_stderr = receive_proc.communicate(timeout=SEND_TIMEOUT)
+            send_proc.wait(timeout=max(0.0, deadline - time.monotonic()))
+        except subprocess.TimeoutExpired:
+            send_proc.kill()
+            receive_proc.kill()
+            send_proc.wait()
+            receive_proc.wait()
+            send_stderr_file.seek(0)
+            raise ReplicationTimeoutError(
+                f"btrfs send/receive from {remote_host} timed out after {SEND_TIMEOUT}s: "
+                f"{send_stderr_file.read().decode(errors='replace')}"
+            ) from None
+
+        if send_proc.returncode != 0 or receive_proc.returncode != 0:
+            send_stderr_file.seek(0)
+            raise ReplicationError(
+                f"btrfs send/receive from {remote_host} failed "
+                f"(send: {send_proc.returncode}, receive: {receive_proc.returncode}): "
+                f"{send_stderr_file.read().decode(errors='replace')} "
+                f"{receive_stderr.decode(errors='replace')}"
+            )
+
+    return receive_stdout.decode(errors="replace")
 
 
 def snapshots_on_remote(remote_host, remote_path, port):
@@ -488,6 +562,107 @@ def snapshot_send(req):
     keep_trace(snapshot, remote_host)
 
     return {"Err": ""}
+
+
+# One receive at a time. A `btrfs receive` that stops early leaves behind what
+# it was writing, under the name the whole snapshot would have carried, and the
+# endpoint below takes that leftover away to try again without a parent. Two
+# calls at once would each take away what the other is writing, and neither
+# could say the half received copy was its own.
+receiving = threading.Lock()
+
+
+def is_a_whole_snapshot(path):
+    """Whether this holds a whole snapshot, and not half of one.
+
+    `btrfs receive` makes what it wrote read-only once it has written all of
+    it. A subvolume of the right name that can still be written to is what a
+    transfer that stopped early left behind, and nothing in it says how much of
+    the volume made it over.
+    """
+    return "readonly" in btrfs.Subvolume(path).show()["Flags"]
+
+
+def receive_or_clean(remote_host, remote_snapshot_path, path, remote_parent_path, port):
+    """Receive into `path`, and take away what is left there when it fails.
+
+    That leftover is the only thing deleted, and this call is the one that
+    created it, which the lock above is what makes true. Leaving it would stop
+    every later call, none of them being able to tell that name from a
+    snapshot.
+    """
+    try:
+        run_btrfs_receive(remote_host, remote_snapshot_path, remote_parent_path, port)
+    except ReplicationError:
+        if os.path.exists(path):
+            try:
+                btrfs.Subvolume(path).delete()
+            except BtrfsError as e:
+                log.warning("Could not take away the half received %s: %s", basename(path), e)
+        raise
+
+
+@route("/VolumeDriver.Snapshot.Receive")
+def snapshot_receive(req):
+    """Fetch from another host the most recent snapshot it has of a volume"""
+    test = req.get("Test", False)
+    volume = req["Name"]
+    remote_host = req["Host"]
+
+    validate_volume_name(volume)
+    validate_hostname(remote_host)
+    remote_snapshots = SNAPSHOTS_PATH if not test else TEST_REMOTE_PATH
+    port = os.getenv("SSH_PORT", "1122")
+
+    with receiving:
+        # the command names a volume, not a snapshot: whoever receives does not
+        # know what the other host has, which is the question being asked here
+        found = snapshot_to_fetch(
+            volume,
+            snapshots_on_remote(remote_host, remote_snapshots, port),
+            os.listdir(SNAPSHOTS_PATH),
+        )
+        if not found:
+            raise SnapshotNotFoundError(f"{remote_host} keeps no snapshot of volume '{volume}'")
+        snapshot, parent = found
+        path = snapshotpath(str(snapshot))
+
+        if os.path.exists(path):
+            if not is_a_whole_snapshot(path):
+                # the send side reads what the other host holds from a trace
+                # written after a transfer went through, so it never says yes
+                # by mistake. Here the answer is a name in a directory, which
+                # a transfer that failed leaves behind just the same.
+                raise ReplicationError(
+                    f"'{snapshot}' is here already but holds half a volume, left by a receive "
+                    f"that stopped early. Delete it with `buttervolume rm {snapshot}` to fetch "
+                    "it again"
+                )
+            log.info("Snapshot %s is already here, nothing to receive", snapshot)
+            keep_trace(snapshot, remote_host)
+            return {"Err": "", "Snapshot": str(snapshot)}
+
+        remote_path = join(remote_snapshots, str(snapshot))
+        parent_path = join(remote_snapshots, str(parent)) if parent else None
+        try:
+            log.info("Receiving snapshot %s from %s with parent %s", snapshot, remote_host, parent)
+            receive_or_clean(remote_host, remote_path, path, parent_path, port)
+        except ReplicationTimeoutError:
+            # receiving the whole volume would cross the same stalled link, and
+            # wait as long again: a transfer killed for hanging is not retried
+            raise
+        except ReplicationError as e:
+            if not parent_path:
+                raise
+            log.warning(
+                "Failed receiving %s with parent %s, receiving it whole: %s", snapshot, parent, e
+            )
+            receive_or_clean(remote_host, remote_path, path, None, port)
+
+        # that host holds this snapshot, we have just read it there. Without
+        # this trace the first send back would carry the whole volume again.
+        keep_trace(snapshot, remote_host)
+        return {"Err": "", "Snapshot": str(snapshot)}
 
 
 # One snapshot at a time. The endpoint below takes a copy, compares it with the

--- a/buttervolume/plugin.py
+++ b/buttervolume/plugin.py
@@ -38,6 +38,7 @@ from buttervolume import (
 from buttervolume.btrfs import BtrfsError
 from buttervolume.config import (
     DTFORMAT,
+    REMOTE_TIMEOUT,
     RSYNC_TIMEOUT,
     SCHEDULE,
     SCHEDULE_DISABLED,
@@ -204,6 +205,46 @@ def run_btrfs_send_receive(
             )
 
     return receive_stdout.decode()
+
+
+def snapshots_on_remote(remote_host, remote_path, port):
+    """The names this host keeps in that directory.
+
+    An empty answer means it answered and keeps nothing there. A host that
+    could not answer raises instead, and is never read as a host with nothing:
+    acting on "there is nothing over there" when nobody said so is how the
+    good copy of a volume gets replaced by an older one.
+
+    The whole directory is listed rather than a `volume@*` pattern. The
+    pattern would carry a name into a shell on the other machine, and `ls`
+    leaves with the same non-zero status when nothing matches as when it
+    failed, which is exactly the difference this function exists to keep.
+    """
+    validate_hostname(remote_host)
+    ssh_cmd = [
+        "ssh",
+        "-p",
+        port,
+        "-o",
+        "StrictHostKeyChecking=no",
+        remote_host,
+        f"ls -1 {remote_path}",
+    ]
+    try:
+        listing = subprocess.run(ssh_cmd, capture_output=True, timeout=REMOTE_TIMEOUT)
+    except subprocess.TimeoutExpired:
+        raise ReplicationTimeoutError(
+            f"{remote_host} did not say what it keeps within {REMOTE_TIMEOUT}s"
+        ) from None
+    if listing.returncode != 0:
+        raise ReplicationError(
+            f"Could not read the snapshots of {remote_host}: "
+            f"{listing.stderr.decode(errors='replace')}"
+        )
+    # nothing is decoded strictly: a name we cannot read is one this host
+    # should not have written, and it is refused later by name rather than
+    # here by an error nobody expected
+    return listing.stdout.decode(errors="replace").splitlines()
 
 
 @route("/Plugin.Activate")

--- a/buttervolume/plugin.py
+++ b/buttervolume/plugin.py
@@ -355,6 +355,30 @@ def driver_cap(_):
     return {"Capabilities": {"Scope": "local"}}
 
 
+def keep_trace(snapshot, remote_host):
+    """Remember that this host holds this snapshot, and forget the older ones.
+
+    That trace is the whole memory of what is over there: a later send reads it
+    to know there is nothing to send, and an incremental one is built on the
+    snapshot it was made from. The traces of the previous exchanges with that
+    host go, since this one says the same thing about a more recent snapshot;
+    the snapshots they were made from stay, and a purge takes them when its
+    pattern says so.
+    """
+    trace = snapshot.sent_to(remote_host)
+    if not os.path.exists(snapshotpath(str(trace))):
+        btrfs.Subvolume(snapshotpath(str(snapshot))).snapshot(
+            snapshotpath(str(trace)), readonly=True
+        )
+    for old in sent_snapshots(snapshot.volume, remote_host, os.listdir(SNAPSHOTS_PATH)):
+        if old == trace:
+            continue
+        try:
+            btrfs.Subvolume(snapshotpath(str(old))).delete()
+        except Exception as e:
+            log.warning("Failed to delete old snapshot %s: %s", str(old), str(e))
+
+
 @route("/VolumeDriver.Snapshot.Send")
 def snapshot_send(req):
     """The last sent snapshot is remembered by adding a suffix with the target"""
@@ -420,17 +444,7 @@ def snapshot_send(req):
         # Send without parent
         run_btrfs_send_receive(snapshot_path, remote_host, remote_snapshots, None, port)
 
-    # Create local tracking snapshot
-    btrfs.Subvolume(snapshot_path).snapshot(
-        snapshotpath(str(snapshot.sent_to(remote_host))), readonly=True
-    )
-
-    # Clean up old tracking snapshots
-    for old_snapshot in already_sent:
-        try:
-            btrfs.Subvolume(snapshotpath(str(old_snapshot))).delete()
-        except Exception as e:
-            log.warning("Failed to delete old snapshot %s: %s", str(old_snapshot), str(e))
+    keep_trace(snapshot, remote_host)
 
     return {"Err": ""}
 

--- a/test.py
+++ b/test.py
@@ -40,6 +40,7 @@ from buttervolume.names import (
     Snapshot,
     new_snapshot,
     sent_snapshots,
+    snapshot_to_fetch,
     snapshots_of,
 )
 from buttervolume.purge import Pattern, compute_purges
@@ -1699,6 +1700,43 @@ class TestNames(unittest.TestCase):
         self.assertEqual(str(already_sent[-1].without_host()), "www@t2")
         # and the trace this send will leave behind
         self.assertEqual(str(Snapshot.parse("www@t3").sent_to("node2")), "www@t3@node2")
+
+
+class TestWhatToFetch(unittest.TestCase):
+    """What to ask a host for, read from two listings and nothing else"""
+
+    def test_the_most_recent_snapshot_over_there_is_the_one_to_fetch(self):
+        remote = ["www@t1", "www@t2", "www@t3", "other@t9"]
+        local = ["www@t1", "www@t2"]
+        snapshot, parent = snapshot_to_fetch("www", remote, local)
+        self.assertEqual(str(snapshot), "www@t3")
+        # the most recent one both sides already hold, which is what an
+        # incremental transfer is built on
+        self.assertEqual(str(parent), "www@t2")
+
+    def test_a_trace_is_neither_fetched_nor_taken_for_a_parent(self):
+        # that host keeps the traces of its own sends next to its snapshots,
+        # and www@t3@node3 sorts after www@t3
+        remote = ["www@t1", "www@t2", "www@t2@node3"]
+        local = ["www@t1", "www@t1@node3"]
+        snapshot, parent = snapshot_to_fetch("www", remote, local)
+        self.assertEqual(str(snapshot), "www@t2")
+        self.assertEqual(str(parent), "www@t1")
+
+    def test_two_sides_with_nothing_in_common_have_no_parent(self):
+        snapshot, parent = snapshot_to_fetch("www", ["www@t2"], ["www@t1"])
+        self.assertEqual(str(snapshot), "www@t2")
+        # the whole volume has to come over
+        self.assertIsNone(parent)
+
+    def test_a_host_that_keeps_nothing_of_this_volume_asks_for_nothing(self):
+        self.assertIsNone(snapshot_to_fetch("www", ["other@t1", "wwwbis@t1"], ["www@t1"]))
+
+    def test_a_name_of_this_volume_that_nobody_can_read_stops_everything(self):
+        # leaving it out would answer "that host keeps nothing", which is
+        # exactly the wrong answer to a listing we could not read
+        with self.assertRaises(ValidationError):
+            snapshot_to_fetch("www", ["www@t1", "www@t 2"], [])
 
 
 class TestPurgePattern(unittest.TestCase):

--- a/test.py
+++ b/test.py
@@ -1921,6 +1921,13 @@ class TestWhatToFetch(unittest.TestCase):
         with self.assertRaises(ValidationError):
             snapshot_to_fetch("www", ["www@t1", "www@t 2"], [])
 
+    def test_a_stray_file_of_our_own_stops_nothing(self):
+        # our own directory is not a listing we have to make sense of: whatever
+        # left that name behind, it is not one of the snapshots over there
+        snapshot, parent = snapshot_to_fetch("www", ["www@t1", "www@t2"], ["www@t1", "www@t 2"])
+        self.assertEqual(str(snapshot), "www@t2")
+        self.assertEqual(str(parent), "www@t1")
+
 
 class TestPurgePattern(unittest.TestCase):
     """The retention pattern, read without touching a filesystem"""

--- a/test.py
+++ b/test.py
@@ -575,6 +575,189 @@ class TestCase(unittest.TestCase):
         with open(join(VOLUMES_PATH, target, "foobar")) as f:
             self.assertEqual(f.read(), "foobar")
 
+    def test_a_host_that_cannot_answer_is_not_read_as_an_empty_host(self):
+        """A listing nobody could read is an error, never a host with nothing"""
+        name = PREFIX_TEST_VOLUME + uuid.uuid4().hex
+        self.create_a_volume_with_a_file(name)
+        # port 1 is refused, like a host that is down
+        with patch.dict(os.environ, {"SSH_PORT": "1"}):
+            resp = jsonloads(
+                self.app.post(
+                    "/VolumeDriver.Snapshot.Receive",
+                    json.dumps({"Name": name, "Host": "localhost", "Test": True}),
+                ).body
+            )
+        self.assertIn("Could not read the snapshots of localhost", resp["Err"])
+        # and nothing was invented: no snapshot, and no answer naming one
+        self.assertNotIn("Snapshot", resp)
+        self.assertEqual([s for s in os.listdir(SNAPSHOTS_PATH) if s.startswith(name + "@")], [])
+
+    def test_receiving_a_snapshot_we_already_have_transfers_nothing(self):
+        """A snapshot already here is answered without crossing the network"""
+        name = PREFIX_TEST_VOLUME + uuid.uuid4().hex
+        self.create_a_volume_with_a_file(name)
+        snapshot = jsonloads(
+            self.app.post("/VolumeDriver.Snapshot", json.dumps({"Name": name})).body
+        )["Snapshot"]
+
+        with patch("buttervolume.plugin.snapshots_on_remote") as listing:
+            listing.return_value = [snapshot]
+            with patch("buttervolume.plugin.run_btrfs_receive") as transfer:
+                resp = jsonloads(
+                    self.app.post(
+                        "/VolumeDriver.Snapshot.Receive",
+                        json.dumps({"Name": name, "Host": "localhost", "Test": True}),
+                    ).body
+                )
+        transfer.assert_not_called()
+        self.assertEqual(resp, {"Err": "", "Snapshot": snapshot})
+        # and that host is now known to hold it, so a send will not carry it
+        self.assertIn(f"{snapshot}@localhost", os.listdir(SNAPSHOTS_PATH))
+
+    def test_a_leftover_from_an_interrupted_receive_is_not_taken_for_a_snapshot(self):
+        """What a receive left half written carries the name of a whole one"""
+        name = PREFIX_TEST_VOLUME + uuid.uuid4().hex
+        self.create_a_volume_with_a_file(name)
+        half = f"{name}@2026-02-01T00:00:00.000000"
+        # what btrfs receive leaves behind when it stops early: the final name,
+        # and a subvolume still open to writing
+        btrfs.Subvolume(join(VOLUMES_PATH, name)).snapshot(join(SNAPSHOTS_PATH, half))
+
+        with patch("buttervolume.plugin.snapshots_on_remote") as listing:
+            listing.return_value = [half]
+            resp = jsonloads(
+                self.app.post(
+                    "/VolumeDriver.Snapshot.Receive",
+                    json.dumps({"Name": name, "Host": "localhost", "Test": True}),
+                ).body
+            )
+        self.assertIn("holds half a volume", resp["Err"])
+        # and it is still there: nothing is deleted on our own initiative
+        self.assertTrue(os.path.exists(join(SNAPSHOTS_PATH, half)))
+
+    @unittest.skipIf(
+        os.environ.get("BUTTERVOLUME_LOCAL_TEST"), "SSH not available in local test mode"
+    )
+    def test_a_host_that_holds_nothing_says_so(self):
+        """A host that answered and keeps nothing is not an error, but no snapshot"""
+        name = PREFIX_TEST_VOLUME + uuid.uuid4().hex
+        resp = jsonloads(
+            self.app.post(
+                "/VolumeDriver.Snapshot.Receive",
+                json.dumps({"Name": name, "Host": "localhost", "Test": True}),
+            ).body
+        )
+        self.assertIn("keeps no snapshot", resp["Err"])
+
+    @unittest.skipIf(
+        os.environ.get("BUTTERVOLUME_LOCAL_TEST"), "SSH not available in local test mode"
+    )
+    def test_a_snapshot_received_from_another_host_restores(self):
+        """What comes back from another host is the volume it was taken from"""
+        name = PREFIX_TEST_VOLUME + uuid.uuid4().hex
+        self.create_a_volume_with_a_file(name)
+        snapshot = jsonloads(
+            self.app.post("/VolumeDriver.Snapshot", json.dumps({"Name": name})).body
+        )["Snapshot"]
+        self.app.post(
+            "/VolumeDriver.Snapshot.Send",
+            json.dumps({"Name": snapshot, "Host": "localhost", "Test": True}),
+        )
+        # this host loses the snapshot and the volume drifts away from it
+        btrfs.Subvolume(join(SNAPSHOTS_PATH, snapshot)).delete()
+        with open(join(VOLUMES_PATH, name, "foobar"), "w") as f:
+            f.write("lost")
+
+        resp = jsonloads(
+            self.app.post(
+                "/VolumeDriver.Snapshot.Receive",
+                json.dumps({"Name": name, "Host": "localhost", "Test": True}),
+            ).body
+        )
+        self.assertEqual(resp["Snapshot"], snapshot)
+        self.app.post("/VolumeDriver.Snapshot.Restore", json.dumps({"Name": snapshot}))
+        with open(join(VOLUMES_PATH, name, "foobar")) as f:
+            self.assertEqual(f.read(), "foobar")
+
+    @unittest.skipIf(
+        os.environ.get("BUTTERVOLUME_LOCAL_TEST"), "SSH not available in local test mode"
+    )
+    def test_receiving_again_only_carries_the_difference(self):
+        """The second receive is built on the snapshot both sides already hold"""
+        name = PREFIX_TEST_VOLUME + uuid.uuid4().hex
+        self.create_a_volume_with_a_file(name)
+        first = jsonloads(self.app.post("/VolumeDriver.Snapshot", json.dumps({"Name": name})).body)[
+            "Snapshot"
+        ]
+        self.app.post(
+            "/VolumeDriver.Snapshot.Send",
+            json.dumps({"Name": first, "Host": "localhost", "Test": True}),
+        )
+        with open(join(VOLUMES_PATH, name, "foobar"), "w") as f:
+            f.write("changed foobar")
+        second = jsonloads(
+            self.app.post("/VolumeDriver.Snapshot", json.dumps({"Name": name})).body
+        )["Snapshot"]
+        self.app.post(
+            "/VolumeDriver.Snapshot.Send",
+            json.dumps({"Name": second, "Host": "localhost", "Test": True}),
+        )
+        # this host keeps the first snapshot and loses the second one
+        btrfs.Subvolume(join(SNAPSHOTS_PATH, second)).delete()
+        with open(join(VOLUMES_PATH, name, "foobar"), "w") as f:
+            f.write("lost")
+
+        with self.assertLogs(level=logging.INFO) as captured:
+            resp = jsonloads(
+                self.app.post(
+                    "/VolumeDriver.Snapshot.Receive",
+                    json.dumps({"Name": name, "Host": "localhost", "Test": True}),
+                ).body
+            )
+        self.assertEqual(resp["Snapshot"], second)
+        # only the difference crossed: the snapshot both sides hold was asked
+        # for as the parent, and nothing fell back to the whole volume. Both
+        # hosts share a filesystem here, so what this proves is that the parent
+        # was accepted, not that it would be between two machines.
+        self.assertTrue(any(f"with parent {first}" in m for m in captured.output))
+        self.assertFalse(any("receiving it whole" in m for m in captured.output))
+        self.app.post("/VolumeDriver.Snapshot.Restore", json.dumps({"Name": second}))
+        with open(join(VOLUMES_PATH, name, "foobar")) as f:
+            self.assertEqual(f.read(), "changed foobar")
+
+    @unittest.skipIf(
+        os.environ.get("BUTTERVOLUME_LOCAL_TEST"), "SSH not available in local test mode"
+    )
+    def test_a_received_snapshot_is_not_sent_back_to_the_host_it_came_from(self):
+        """Receiving leaves the same trace as sending, and says the same thing"""
+        name = PREFIX_TEST_VOLUME + uuid.uuid4().hex
+        self.create_a_volume_with_a_file(name)
+        snapshot = jsonloads(
+            self.app.post("/VolumeDriver.Snapshot", json.dumps({"Name": name})).body
+        )["Snapshot"]
+        self.app.post(
+            "/VolumeDriver.Snapshot.Send",
+            json.dumps({"Name": snapshot, "Host": "localhost", "Test": True}),
+        )
+        # this host forgets everything, the way another machine would never
+        # have known it
+        for leftover in [s for s in os.listdir(SNAPSHOTS_PATH) if s.startswith(name + "@")]:
+            btrfs.Subvolume(join(SNAPSHOTS_PATH, leftover)).delete()
+
+        self.app.post(
+            "/VolumeDriver.Snapshot.Receive",
+            json.dumps({"Name": name, "Host": "localhost", "Test": True}),
+        )
+        with patch("buttervolume.plugin.run_btrfs_send_receive") as transfer:
+            resp = jsonloads(
+                self.app.post(
+                    "/VolumeDriver.Snapshot.Send",
+                    json.dumps({"Name": snapshot, "Host": "localhost", "Test": True}),
+                ).body
+            )
+        self.assertEqual(resp, {"Err": ""})
+        transfer.assert_not_called()
+
     def test_snapshot(self):
         """Check we can snapshot a volume"""
         # create a volume with a file


### PR DESCRIPTION
Buttervolume could send a snapshot to another host and never fetch one back, so
a container moved to a second machine started on the empty volume of that
machine while its data sat next door. `buttervolume receive <host> <volume>` is
the other direction. It is the piece a synchronization at mount time needs,
extracted from #69 on its own, and it does not touch mount or unmount.

It names a volume where `send` names a snapshot, because whoever receives does
not know what the other host has, which is the question being asked. The most
recent snapshot that host keeps is fetched, incrementally when the two sides
still share an older one to build on, and its name is printed. It restores
nothing: which snapshot becomes the volume is a separate decision, and this
command is not entitled to make it.

**A host that could not answer is never read as a host with nothing.** The
version of this in #69 reads the standard output of ssh and never looks at its
return code, so a host that is down answers an empty listing, which reads as a
host that keeps no snapshot. Acting on that is how the good copy of a volume
gets replaced by an older one while the machine holding it was simply
unreachable. Here the listing raises when ssh fails and when it takes too long,
and an empty answer only ever means a host that answered and keeps nothing.
The whole directory is listed rather than a `volume@*` pattern, because `ls`
leaves with the same non-zero status when nothing matches as when it failed,
and because the pattern would carry a name into a shell on the other machine.

**A trace is not a snapshot.** Choosing what to fetch is a computation on two
lists of names, so it lives with the naming rules and is tested without ssh or
BTRFS. Only the snapshots count: a host keeps its own `www@date@node3` next to
them, that name sorts after the snapshot it was made from, and fetching it
would write locally the trace of a send nobody made, which the next send to
node3 would then build on.

**What a receive leaves half written carries the name of a whole snapshot.** So
the answer to "do we have it already" cannot be the presence of that name, the
way the send side can read a trace it only writes after a transfer went
through. A subvolume that is not read-only is what a receive left behind, and
it is named in the error rather than deleted behind the back of whoever might
want to look at it. The one this call created itself is taken away, so a failed
transfer does not block every later one, and a lock is what makes "this one is
mine" true.

**The exchange is remembered.** The trace `<volume>@<datetime>@<host>` is
written after a receive as it is after a send, since a snapshot that just
arrived from a host is a snapshot that host holds. Without it, a host that
received a volume would send the whole of it back the first time it changed, to
the host it came from. Writing that trace now has one place instead of two.

Verified: `96 passed, 10 skipped` under `test_local.sh` and `106 passed` under
`./test.sh`. Twelve new tests, among them two that **restore** what came back
and read the file, one that proves an unreachable host is an error and not an
empty host, one that proves the incremental transfer asks for the parent both
sides hold and never falls back to the whole volume, and one that proves a
received snapshot is not sent straight back.

One thing those tests cannot prove, and the comment in them says so: both hosts
share a filesystem on the test bench, so the parent of an incremental receive
is found there by its received UUID. Between two real machines the local parent
is the original rather than a copy, and `btrfs receive` falls back to looking it
up by plain UUID. Should that ever fail, the whole volume comes over instead,
which is the same fallback the send side has always had.
