### PR TITLE
Run the plugin on Debian 13

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,8 +1,8 @@
 CHANGELOG
 =========
 
-3.13 (unreleased)
-*****************
+4.0 (unreleased)
+****************
 
 - The Docker plugin now runs on Debian 13, which brings Python 3.13 and
   btrfs-progs 6.14. The installed application no longer lands in the

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,16 @@ CHANGELOG
 3.13 (unreleased)
 *****************
 
+- The Docker plugin now runs on Debian 13, which brings Python 3.13 and
+  btrfs-progs 6.14. The installed application no longer lands in the
+  interpreter's site-packages directory but in ``/app``, so the next Debian
+  upgrade no longer has to remember to change a Python version written down in
+  the Dockerfile.
+
+  The image now asks for ``e2fsprogs`` by name. Debian 12 happened to carry it
+  along, Debian 13 does not, and without it ``chattr`` is missing, which is how
+  the ``nocow`` and ``compression`` options are applied to a volume.
+
 - Buttervolume can now receive a snapshot from another host, where it could
   only send one. ``buttervolume receive <host> <volume>`` fetches the most
   recent snapshot that host keeps of that volume, incrementally when the two

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage - includes development tools
-FROM debian:12 AS builder
+FROM debian:13 AS builder
 MAINTAINER Christophe Combelles. <ccomb@free.fr>
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -22,13 +22,14 @@ RUN mkdir /usr/src/buttervolume \
     && uv pip install --target /app .
 
 # Runtime stage - minimal dependencies
-FROM debian:12-slim
+FROM debian:13-slim
 LABEL maintainer="Christophe Combelles <ccomb@free.fr>"
 
 # Install runtime dependencies and create directories in one layer
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         btrfs-progs \
+        e2fsprogs \
         ca-certificates \
         python3 \
         python3-pytest \
@@ -45,8 +46,9 @@ RUN apt-get update \
     && mkdir -p /etc/buttervolume /root/.ssh
 
 # Copy the built application from builder stage
-COPY --from=builder /app /usr/local/lib/python3.11/site-packages/
-ENV PYTHONPATH=/usr/local/lib/python3.11/site-packages
+COPY --from=builder /app /app
+ENV PYTHONPATH=/app
+ENV PATH="/app/bin:$PATH"
 
 # add tini to avoid sshd zombie processes
 ENV TINI_VERSION=v0.19.0

--- a/buttervolume/cli.py
+++ b/buttervolume/cli.py
@@ -46,7 +46,7 @@ from buttervolume.purge import Pattern
 from buttervolume.schedule import Job, Purge, read_schedule, write_schedule
 from buttervolume.scheduler import scheduler
 
-VERSION = "3.13.0"
+VERSION = "4.0.0"
 logging.basicConfig(level=LOGLEVEL)
 log = logging.getLogger()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "buttervolume"
-version = "3.13.0"
+version = "4.0.0"
 description = "BTRFS Volume plugin for Docker"
 readme = "README.rst"
 requires-python = ">=3.11"

--- a/test.py
+++ b/test.py
@@ -19,8 +19,7 @@ import threading
 import time
 import unittest
 import uuid
-import weakref
-from contextlib import suppress
+from contextlib import contextmanager, suppress
 from datetime import datetime, timedelta
 from os.path import join
 from subprocess import CalledProcessError, check_output, run
@@ -1688,7 +1687,7 @@ class TestCase(unittest.TestCase):
         self.create_a_volume_with_a_file(name)
         # We can't use same subvolume name twice on the same host so use a
         # non btrf directory for testing purpose
-        with TemporaryDirectory(path=remote_path) as remote_path:
+        with temporary_directory(remote_path) as remote_path:
             with open(join(remote_path, "foobar"), "w") as f:
                 f.write("test sync")
             self.app.post(
@@ -1758,7 +1757,7 @@ class TestCase(unittest.TestCase):
             LAST_RUNS,
             {"synchronize:localhost,wronghost.mlf": {name: datetime.now() - timedelta(days=1)}},
         )
-        with TemporaryDirectory(path=remote_path) as remote_path:
+        with temporary_directory(remote_path) as remote_path:
             with open(join(remote_path, "foobar"), "w") as f:
                 f.write("test sync")
             runjobs(SCHEDULE, test=True, last_runs=LAST_RUNS)
@@ -2269,33 +2268,22 @@ class TestLastRunsFile(unittest.TestCase):
         self.assertTrue(left[0].startswith("lastruns.csv."), left)
 
 
-class TemporaryDirectory(tempfile.TemporaryDirectory):
-    """Create and return a temporary directory. This change the
-    tempfile.TemporaryDirectory behavior by letting user provide his wished
-    directory, if directory already exists that directory and everything
-    contained in it are removed.  For
-    example:
-        with TemporaryDirectory('/tmp/mydir') as tmpdir:
-            ...
-    Upon exiting the context, the directory and everything contained
-    in it are removed.
+@contextmanager
+def temporary_directory(path):
+    """Give an empty directory at the path of your choosing.
+
+    Whatever was already there is removed on the way in, and the directory is
+    removed again on the way out. ``tempfile.TemporaryDirectory`` picks the
+    path itself, and subclassing it to say where meant copying private
+    attributes it renames from one Python version to the next.
     """
-
-    def __init__(self, suffix=None, prefix=None, dir=None, path=None):
-        self.name = self.mkdir(path) if path else tempfile.mkdtemp(suffix, prefix, dir)
-        self._ignore_cleanup_errors = False  # Add missing attribute for Python 3.11+ compatibility
-        self._finalizer = weakref.finalize(
-            self,
-            self._cleanup,
-            self.name,
-            warn_message=f"Implicitly cleaning up {self!r}",
-        )
-
-    def mkdir(self, path):
-        if os.path.isdir(path):
-            shutil.rmtree(path)
-        os.mkdir(path, 0o700)
-        return path
+    if os.path.isdir(path):
+        shutil.rmtree(path)
+    os.mkdir(path, 0o700)
+    try:
+        yield path
+    finally:
+        shutil.rmtree(path)
 
 
 if __name__ == "__main__":

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.11"
 resolution-markers = [
     "python_full_version >= '3.13'",
@@ -30,7 +30,7 @@ wheels = [
 
 [[package]]
 name = "buttervolume"
-version = "3.13.0"
+version = "4.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "bottle" },


### PR DESCRIPTION
Debian 13 brings Python 3.13 and btrfs-progs 6.14 to the plugin image. Three
things had to move for the base system to change.

The Dockerfile wrote the Python version down twice, in the path the installed
application was copied to and in `PYTHONPATH`. The application now stays in
`/app`, with `/app/bin` on `PATH`, and the Dockerfile no longer names a Python
version at all, so the next Debian upgrade is one line.

Debian 12 carried `e2fsprogs` along without being asked and Debian 13 does not.
Without it `chattr` is missing, and `chattr` is how the `nocow` and
`compression` options are applied to a volume, so the image now asks for the
package by name.

The test suite subclassed `tempfile.TemporaryDirectory` to choose the directory
itself, which meant copying private attributes that `tempfile` renames from one
Python version to the next: 3.11 needed `_ignore_cleanup_errors`, 3.13 wants
`_delete`. A ten-line context manager does the same job and has nothing to keep
up with.

The second commit renames the release being prepared from 3.13 to 4.0, since a
new base system under the plugin makes it a major release.

## How it was checked

- The full suite inside the Debian 13 image, the way `test.sh` runs it:
  `107 passed`. Before the three fixes above it was `3 failed, 104 passed`.
- `test_local.sh`: `97 passed, 10 skipped`.
- `buttervolume --help` answers inside the built image, on Python 3.13.5.

One thing worth a second pair of eyes: before this change the console script
landed in `.../site-packages/bin/`, which is on no `PATH`. I did not rebuild the
old image to confirm what that meant in practice, so I am not claiming it was
broken, only that the new layout puts the script somewhere the shell can find.
