### PR TITLE
Build the plugin image on Alpine

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,11 @@ CHANGELOG
 4.0 (unreleased)
 ****************
 
+- A volume asked to do without copy on write is now checked by a test. The
+  plugin asks ``chattr`` for the C flag and swallows a failure, so an image
+  missing ``chattr``, or carrying one that does not know that flag, would have
+  produced ordinary volumes and said nothing.
+
 - The Docker plugin now runs on Debian 13, which brings Python 3.13 and
   btrfs-progs 6.14. The installed application no longer lands in the
   interpreter's site-packages directory but in ``/app``, so the next Debian

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,10 +22,10 @@ CHANGELOG
   ``known_hosts`` is refreshed. The keys published up to 3.13 should be treated
   as known to everyone.
 
-- The plugin image is built on Alpine rather than Debian, and goes from 185 MB
-  to 72 MB. Nothing of buttervolume changed: the weight was the base system.
-  Debian brought coreutils, perl, bash, dpkg, apt, util-linux and systemd,
-  around 90 MB that a volume plugin never calls, systemd arriving as a
+- The plugin image is built on Alpine rather than Debian 12, and goes from
+  185 MB to 72 MB. Nothing of buttervolume changed: the weight was the base
+  system. Debian brought coreutils, perl, bash, dpkg, apt, util-linux and
+  systemd, around 90 MB that a volume plugin never calls, systemd arriving as a
   dependency of the ssh server. Busybox and apk do the same work in 2 MB.
 
   Alpine packages tini, so the Dockerfile no longer downloads it from GitHub at
@@ -35,23 +35,22 @@ CHANGELOG
   The entrypoint is plain sh instead of bash, which Alpine does not carry, and
   starts sshd directly since there is no ``service`` command.
 
-  Alpine 3.22 carries Python 3.12 where Debian 13 carried 3.13. Buttervolume
-  asks for 3.11 or later, so this changes nothing, but it is worth knowing.
+  The installed application no longer lands in the interpreter's site-packages
+  directory but in ``/app``, so the Dockerfile no longer writes a Python
+  version down anywhere and the next base system upgrade is one line.
+
+  The image asks for ``e2fsprogs-extra`` by name, because busybox otherwise
+  leaves its own smaller ``chattr`` and ``lsattr`` in place, and ``chattr`` is
+  how the ``nocow`` and ``compression`` options are applied to a volume.
+
+  Alpine 3.22 carries Python 3.12 and btrfs-progs 6.14, where Debian 12 carried
+  Python 3.11. Buttervolume asks for 3.11 or later, so this changes nothing,
+  but it is worth knowing.
 
 - A volume asked to do without copy on write is now checked by a test. The
   plugin asks ``chattr`` for the C flag and swallows a failure, so an image
   missing ``chattr``, or carrying one that does not know that flag, would have
   produced ordinary volumes and said nothing.
-
-- The Docker plugin now runs on Debian 13, which brings Python 3.13 and
-  btrfs-progs 6.14. The installed application no longer lands in the
-  interpreter's site-packages directory but in ``/app``, so the next Debian
-  upgrade no longer has to remember to change a Python version written down in
-  the Dockerfile.
-
-  The image now asks for ``e2fsprogs`` by name. Debian 12 happened to carry it
-  along, Debian 13 does not, and without it ``chattr`` is missing, which is how
-  the ``nocow`` and ``compression`` options are applied to a volume.
 
 - Buttervolume can now receive a snapshot from another host, where it could
   only send one. ``buttervolume receive <host> <volume>`` fetches the most

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,24 @@ CHANGELOG
 4.0 (unreleased)
 ****************
 
+- The ssh server inside the plugin now makes its own host keys on the first
+  start, in ``/var/lib/buttervolume/ssh/``, instead of carrying the ones built
+  into the image.
+
+  Up to 3.13 those keys were made while the image was built, so they were part
+  of the published plugin. Everyone pulling a given tag ran the same ssh
+  identity, and anyone could read its private keys out of the image. Someone
+  able to redirect the connection between two hosts could then pass for the
+  host a snapshot was being sent to, and receive the contents of the volume,
+  since the sender's ``known_hosts`` check would pass. Logging in to a plugin
+  was never possible this way: that needs the client key, which has always been
+  made per installation.
+
+  On the first start after upgrading, the plugin presents a new host key, and
+  every host replicating to it reports a changed host key until its
+  ``known_hosts`` is refreshed. The keys published up to 3.13 should be treated
+  as known to everyone.
+
 - The plugin image is built on Alpine rather than Debian, and goes from 185 MB
   to 72 MB. Nothing of buttervolume changed: the weight was the base system.
   Debian brought coreutils, perl, bash, dpkg, apt, util-linux and systemd,
@@ -15,10 +33,7 @@ CHANGELOG
   uv too, so the build stage no longer runs an installer script either.
 
   The entrypoint is plain sh instead of bash, which Alpine does not carry, and
-  starts sshd directly since there is no ``service`` command. The ssh host keys
-  are now made in the Dockerfile, where the Debian package used to make them,
-  so restarting the plugin still does not change the identity the hosts
-  replicating to it already know.
+  starts sshd directly since there is no ``service`` command.
 
   Alpine 3.22 carries Python 3.12 where Debian 13 carried 3.13. Buttervolume
   asks for 3.11 or later, so this changes nothing, but it is worth knowing.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,25 @@ CHANGELOG
 4.0 (unreleased)
 ****************
 
+- The plugin image is built on Alpine rather than Debian, and goes from 185 MB
+  to 72 MB. Nothing of buttervolume changed: the weight was the base system.
+  Debian brought coreutils, perl, bash, dpkg, apt, util-linux and systemd,
+  around 90 MB that a volume plugin never calls, systemd arriving as a
+  dependency of the ssh server. Busybox and apk do the same work in 2 MB.
+
+  Alpine packages tini, so the Dockerfile no longer downloads it from GitHub at
+  build time, and curl leaves with it since nothing else used it. It packages
+  uv too, so the build stage no longer runs an installer script either.
+
+  The entrypoint is plain sh instead of bash, which Alpine does not carry, and
+  starts sshd directly since there is no ``service`` command. The ssh host keys
+  are now made in the Dockerfile, where the Debian package used to make them,
+  so restarting the plugin still does not change the identity the hosts
+  replicating to it already know.
+
+  Alpine 3.22 carries Python 3.12 where Debian 13 carried 3.13. Buttervolume
+  asks for 3.11 or later, so this changes nothing, but it is worth knowing.
+
 - A volume asked to do without copy on write is now checked by a test. The
   plugin asks ``chattr`` for the C flag and swallows a failure, so an image
   missing ``chattr``, or carrying one that does not know that flag, would have

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,68 +1,52 @@
 # Build stage - includes development tools
-FROM debian:13 AS builder
+FROM alpine:3.22 AS builder
 MAINTAINER Christophe Combelles. <ccomb@free.fr>
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN apk add --no-cache \
         python3 \
-        curl \
+        uv \
         ca-certificates \
-        git \
-        unzip \
-    && rm -rf /var/lib/apt/lists/*
-
-# Install uv
-ADD https://astral.sh/uv/install.sh /uv-installer.sh
-RUN sh /uv-installer.sh && rm /uv-installer.sh
-ENV PATH="/root/.local/bin/:$PATH"
+        unzip
 
 COPY buttervolume.zip /
-RUN mkdir /usr/src/buttervolume \
+RUN mkdir -p /usr/src/buttervolume \
     && unzip -d /usr/src/buttervolume buttervolume.zip \
     && cd /usr/src/buttervolume \
     && uv pip install --target /app .
 
 # Runtime stage - minimal dependencies
-FROM debian:13-slim
+FROM alpine:3.22
 LABEL maintainer="Christophe Combelles <ccomb@free.fr>"
 
 # Install runtime dependencies and create directories in one layer
-RUN apt-get update \
-    && apt-get install -y --no-install-recommends \
+# e2fsprogs-extra puts the reference chattr and lsattr where busybox otherwise
+# leaves its own smaller ones, so the copy on write flag is set by the same
+# tool as before
+# tini keeps sshd from leaving zombie processes behind
+# The ssh host keys are made here rather than at startup, as the Debian package
+# used to make them, so that restarting the plugin does not change the identity
+# the hosts replicating to it already know
+RUN apk add --no-cache \
         btrfs-progs \
-        e2fsprogs \
+        e2fsprogs-extra \
         ca-certificates \
         python3 \
-        python3-pytest \
-        python3-webtest \
+        py3-pytest \
+        py3-webtest \
+        openssh \
         openssh-client \
-        openssh-server \
         rsync \
-        curl \
-    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
-    && apt-get clean \
+        tini \
     && mkdir -p /run/docker/plugins \
     && mkdir -p /var/lib/buttervolume/volumes \
     && mkdir -p /var/lib/buttervolume/snapshots \
-    && mkdir -p /etc/buttervolume /root/.ssh
+    && mkdir -p /etc/buttervolume /root/.ssh \
+    && ssh-keygen -A
 
 # Copy the built application from builder stage
 COPY --from=builder /app /app
 ENV PYTHONPATH=/app
 ENV PATH="/app/bin:$PATH"
-
-# add tini to avoid sshd zombie processes
-ENV TINI_VERSION=v0.19.0
-RUN set -eux; \
-    dpkgArch="$(dpkg --print-architecture)"; \
-    case "${dpkgArch##*-}" in \
-        amd64) tiniArch='amd64' ;; \
-        arm64) tiniArch='arm64' ;; \
-        armhf) tiniArch='armhf' ;; \
-        i386) tiniArch='i386' ;; \
-        *) echo >&2 "unsupported architecture: ${dpkgArch}"; exit 1 ;; \
-    esac; \
-    curl -fsSL "https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini-${tiniArch}" -o /tini; \
-    chmod +x /tini
 
 COPY entrypoint.sh /
 ENTRYPOINT ["/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,9 +23,9 @@ LABEL maintainer="Christophe Combelles <ccomb@free.fr>"
 # leaves its own smaller ones, so the copy on write flag is set by the same
 # tool as before
 # tini keeps sshd from leaving zombie processes behind
-# The ssh host keys are made here rather than at startup, as the Debian package
-# used to make them, so that restarting the plugin does not change the identity
-# the hosts replicating to it already know
+# No ssh host key is made here: the image is public, so a key baked into it
+# would be the same on every installation that pulls it. The entrypoint makes
+# them on the first start, in the directory that survives a restart
 RUN apk add --no-cache \
         btrfs-progs \
         e2fsprogs-extra \
@@ -40,8 +40,7 @@ RUN apk add --no-cache \
     && mkdir -p /run/docker/plugins \
     && mkdir -p /var/lib/buttervolume/volumes \
     && mkdir -p /var/lib/buttervolume/snapshots \
-    && mkdir -p /etc/buttervolume /root/.ssh \
-    && ssh-keygen -A
+    && mkdir -p /etc/buttervolume /root/.ssh
 
 # Copy the built application from builder stage
 COPY --from=builder /app /app

--- a/README.rst
+++ b/README.rst
@@ -604,6 +604,17 @@ included in the plugin.
 - Enable ``StrictHostKeyChecking no`` in ``/var/lib/buttervolume/ssh/config``
 - **Important**: Restart Docker daemons after any SSH configuration changes
 
+The ssh server's own host keys are made on the first start, in
+``/var/lib/buttervolume/ssh/``, and kept from one restart to the next. They are
+deliberately not part of the plugin image: an image is public, so a key built
+into it would be the same one on every installation that pulls it, and anyone
+holding it could pass for the host a snapshot is being sent to.
+
+Versions up to 3.13 did build the host keys into the image. On the first start
+after upgrading, this plugin presents a new key, and every host replicating to
+it reports a changed host key until its ``known_hosts`` is refreshed. Those
+published keys should be treated as known to everyone.
+
 The default SSH_PORT of the ssh server included in the plugin is **1122**. You can
 change it with `docker plugin set ccomb/buttervolume SSH_PORT=<PORT>` before
 enabling the plugin.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 SSH_PORT=${SSH_PORT:-1122}
 
@@ -8,11 +8,11 @@ SSH_PORT=${SSH_PORT:-1122}
 mkdir -p /var/lib/buttervolume/config
 mkdir -p /var/lib/buttervolume/ssh
 
-chown -R root: /root/
+chown -R root:root /root/
 sed -r "s/[#]{0,1}Port [0-9]{2,5}/Port $SSH_PORT/g" /etc/ssh/sshd_config -i
-service ssh start
+/usr/sbin/sshd
 
-if [[ $1 == 'test' ]]; then
+if [ "$1" = 'test' ]; then
     set -e
     set -x
     # create ssh key which let root users to access to localhost
@@ -26,5 +26,5 @@ if [[ $1 == 'test' ]]; then
     # Run tests with pytest
     exec python3 -m pytest test.py -v
 else
-    /tini -s -- buttervolume $@
+    /sbin/tini -s -- buttervolume $@
 fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -10,7 +10,21 @@ mkdir -p /var/lib/buttervolume/ssh
 
 chown -R root:root /root/
 sed -r "s/[#]{0,1}Port [0-9]{2,5}/Port $SSH_PORT/g" /etc/ssh/sshd_config -i
-/usr/sbin/sshd
+
+# The ssh host keys live in /root/.ssh, which is the host's
+# /var/lib/buttervolume/ssh, so that they survive a restart. They are made here
+# rather than in the image because an image is public: a key built into it
+# would be the same one on every installation that pulls it, and anyone holding
+# it could pass for the host a snapshot is being sent to.
+for type in rsa ecdsa ed25519; do
+    if [ ! -f "/root/.ssh/ssh_host_${type}_key" ]; then
+        ssh-keygen -q -t "$type" -N "" -f "/root/.ssh/ssh_host_${type}_key"
+    fi
+done
+/usr/sbin/sshd \
+    -h /root/.ssh/ssh_host_rsa_key \
+    -h /root/.ssh/ssh_host_ecdsa_key \
+    -h /root/.ssh/ssh_host_ed25519_key
 
 if [ "$1" = 'test' ]; then
     set -e

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -16,15 +16,20 @@ sed -r "s/[#]{0,1}Port [0-9]{2,5}/Port $SSH_PORT/g" /etc/ssh/sshd_config -i
 # rather than in the image because an image is public: a key built into it
 # would be the same one on every installation that pulls it, and anyone holding
 # it could pass for the host a snapshot is being sent to.
+# A host that cannot make a key or start its ssh server still serves its own
+# volumes, so this does not stop the plugin, but it says so rather than leaving
+# a replication to fail later with nothing explaining why.
 for type in rsa ecdsa ed25519; do
     if [ ! -f "/root/.ssh/ssh_host_${type}_key" ]; then
-        ssh-keygen -q -t "$type" -N "" -f "/root/.ssh/ssh_host_${type}_key"
+        ssh-keygen -q -t "$type" -N "" -f "/root/.ssh/ssh_host_${type}_key" \
+            || echo "buttervolume: could not write the $type ssh host key in /var/lib/buttervolume/ssh" >&2
     fi
 done
 /usr/sbin/sshd \
     -h /root/.ssh/ssh_host_rsa_key \
     -h /root/.ssh/ssh_host_ecdsa_key \
-    -h /root/.ssh/ssh_host_ed25519_key
+    -h /root/.ssh/ssh_host_ed25519_key \
+    || echo "buttervolume: the ssh server did not start, no host can replicate to this one" >&2
 
 if [ "$1" = 'test' ]; then
     set -e

--- a/test.py
+++ b/test.py
@@ -437,6 +437,24 @@ class TestCase(unittest.TestCase):
         self.assertTrue(b"-C-" not in check_output(f"lsattr -d '{path}'", shell=True).split()[0])
         self.app.post("/VolumeDriver.Remove", json.dumps({"Name": name}))
 
+    def test_disabled_cow(self):
+        """Check that asking for no copy on write really turns it off
+
+        The plugin asks chattr for the C flag and swallows a failure, so
+        nothing but the flag itself says whether it was applied.
+        """
+        name = PREFIX_TEST_VOLUME + uuid.uuid4().hex
+        path = join(VOLUMES_PATH, name)
+        resp = jsonloads(
+            self.app.post(
+                "/VolumeDriver.Create",
+                json.dumps({"Name": name, "Opts": {"copyonwrite": "false"}}),
+            ).body
+        )
+        self.assertEqual(resp, {"Err": ""})
+        self.assertIn(b"C", check_output(f"lsattr -d '{path}'", shell=True).split()[0])
+        self.app.post("/VolumeDriver.Remove", json.dumps({"Name": name}))
+
     def test_compression_option(self):
         """Check that compression option works"""
         # Test with compression=true


### PR DESCRIPTION
The plugin image weighed 185 MB. About 90 MB of that was base system a volume
plugin never calls, measured with `dpkg-query` inside the image:

| Package | Size |
|---|---|
| coreutils | 18 MB |
| systemd + libsystemd-shared | 17 MB |
| libc6 | 13 MB |
| dpkg + apt + libapt | 15 MB |
| perl-base | 7.8 MB |
| bash | 7 MB |
| util-linux, passwd, tar | 13 MB |

`systemd` arrives as an alternative dependency of `openssh-server`, which the
plugin does need since it receives snapshots over ssh. Busybox and apk do the
same work in about 2 MB.

**The image is now 72 MB, and the suite passes in it: 108 passed.**

Alpine also packages two things the Dockerfile was fetching over the network at
build time. `tini` is a 27 KB package, so the download from GitHub goes away,
and `curl` goes with it since nothing else used it, in the image or in the
code. `uv` is packaged too, so the build stage stops running an installer
script.

Alpine carries no bash, so the entrypoint is plain sh and starts `sshd`
directly rather than through the `service` command Alpine does not have.

`e2fsprogs-extra` is asked for by name. Busybox otherwise leaves its own
smaller `chattr` and `lsattr` in place. Busybox's `chattr` does handle the C
flag, I checked, but the flag that turns copy on write off is better set by the
tool that has always set it, and the package costs 1 MB.

Alpine 3.22 carries Python 3.12 where Debian 13 carried 3.13. Buttervolume asks
for 3.11 or later, so this changes nothing, but it is worth knowing.

## The ssh host keys, which is the important commit

While moving the base system I looked at where the ssh host keys came from. The
Debian `openssh-server` package makes them in its postinst, which runs during
`docker build`, so they became part of the image. **The plugin published on
Docker Hub carries its private host keys.** Read out of the published layer of
`ccomb/buttervolume:latest`:

```
-rw------- 513  2025-08-03  etc/ssh/ssh_host_ecdsa_key
-rw------- 411  2025-08-03  etc/ssh/ssh_host_ed25519_key
-rw------- 2610 2025-08-03  etc/ssh/ssh_host_rsa_key
```

```
256  SHA256:CERr4AqOv/jk6+QP+U5mQROkLvACB0BfO4iA97FF3O8  root@buildkitsandbox (ED25519)
3072 SHA256:Ru1QPX2Ng5430gJEmBrytrJmcDoadDqzu/7pLb5tb4g  root@buildkitsandbox (RSA)
256  SHA256:WhnF1KT4OOTHLSIjrabjLV8NhIfHogOyluRAyLnTQcc  root@buildkitsandbox (ECDSA)
```

The `root@buildkitsandbox` comment says where they were made. The private keys
are intact and usable. Every tag has its own, shared by everyone who pulls that
tag.

What it allows is impersonation of a receiving host. A host running `send` or
`replicate` checks `known_hosts`; someone able to redirect that connection
holds the matching private key, so the check passes and the `btrfs send`
stream, meaning the contents of the volume, goes to them. Logging in to
somebody's plugin was never possible this way: that needs the client key, which
has always been made per installation. Traffic captured earlier stays safe, ssh
key exchange being ephemeral, so this is an active attack, not a passive one.

The keys are now made on the first start, in `/root/.ssh`, which is the host's
`/var/lib/buttervolume/ssh`, and passed to `sshd` with `-h`. The image contains
none.

**This breaks existing setups once.** On the first start after upgrading, the
plugin presents a new host key and every host replicating to it reports a
changed key until its `known_hosts` is refreshed. The README says so, and says
the keys published up to 3.13 should be treated as known to everyone. The
published tags keep those keys until they are removed from Docker Hub, which is
your call, not something this branch can do.

## The other commit

Nothing proved that `copyonwrite: false` did anything. `btrfs.py` asks `chattr`
for the C flag inside a `contextlib.suppress(BtrfsError)`, so an image whose
`chattr` is missing, or does not know that flag, would hand out ordinary
volumes and say nothing. A test now reads the flag back. It passes on Debian
and on Alpine.

## How it was checked

- The suite inside the Alpine image, the way `test.sh` runs it: `108 passed`.
  The ssh tests exercise the new `sshd -h`.
- `test_local.sh` on a Debian host: `98 passed, 10 skipped`.
- The built image contains no `/etc/ssh/ssh_host_*`.
- Two containers with two different mounted ssh directories get two different
  host keys, and starting the same one twice leaves its key untouched.
- `chattr +C` on a directory in the built image, and `lsattr` showing the flag.

## Adjacent, not fixed here

The README tells users to set `StrictHostKeyChecking no`. Where that advice was
followed, the host key was never checked at all, so the shared key changed
nothing for those setups, and nothing else protected them either. That advice
deserves its own look.
