### PR TITLE
Start the plugin again

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,11 @@ CHANGELOG
 4.0 (unreleased)
 ****************
 
+- The plugin starts again. A docker plugin is not started from the image
+  configuration, so the ``PATH`` and ``PYTHONPATH`` the Dockerfile sets were
+  not there and ``buttervolume`` was not found. The entrypoint sets them
+  itself now, where they hold both for the plugin and for a plain container.
+
 - The ssh server inside the plugin now makes its own host keys on the first
   start, in ``/var/lib/buttervolume/ssh/``, instead of carrying the ones built
   into the image.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,11 @@ CHANGELOG
   not there and ``buttervolume`` was not found. The entrypoint sets them
   itself now, where they hold both for the plugin and for a plain container.
 
+- The ssh server inside the plugin starts again. Alpine's sshd refuses to run
+  unless ``/var/empty`` belongs to root, and that directory arrives owned by
+  whoever unpacked the rootfs while building the plugin. The entrypoint gives
+  it back to root.
+
 - The ssh server inside the plugin now makes its own host keys on the first
   start, in ``/var/lib/buttervolume/ssh/``, instead of carrying the ones built
   into the image.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,5 +1,13 @@
 #!/bin/sh
 
+# A docker plugin is not started from the image configuration: docker gives it
+# the default path and nothing else, so the PATH and PYTHONPATH the Dockerfile
+# sets are missing. They are set again here, where they hold both for the
+# plugin and for a plain container.
+PATH="/app/bin:$PATH"
+PYTHONPATH=/app
+export PATH PYTHONPATH
+
 SSH_PORT=${SSH_PORT:-1122}
 
 # Ensure required directories exist in the mounted volume

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -17,6 +17,10 @@ mkdir -p /var/lib/buttervolume/config
 mkdir -p /var/lib/buttervolume/ssh
 
 chown -R root:root /root/
+# sshd refuses to start unless its privilege separation directory belongs to
+# root. The plugin rootfs is unpacked by whoever ran build.sh, so /var/empty
+# arrives owned by that user.
+chown root:root /var/empty
 sed -r "s/[#]{0,1}Port [0-9]{2,5}/Port $SSH_PORT/g" /etc/ssh/sshd_config -i
 
 # The ssh host keys live in /root/.ssh, which is the host's


### PR DESCRIPTION
`docker plugin enable ccomb/buttervolume:latest` failed with:

```
Error response from daemon: dial unix /run/docker/plugins/8a51.../btrfs.sock: connect: no such file or directory
```

The socket was never created because the entrypoint died. The daemon log gives both reasons:

```
level=error msg="/var/empty must be owned by root and not group or world-writable."
level=error msg="buttervolume: the ssh server did not start, no host can replicate to this one"
level=error msg="[FATAL tini (16)] exec buttervolume failed: No such file or directory"
```

## buttervolume was not on the path

A docker plugin is not started from the image configuration. `docker plugin create` reads `config.json` and `rootfs/`, and the daemon gives the plugin the default path and the variables declared in `config.json`, nothing else. So `ENV PATH="/app/bin:$PATH"` and `ENV PYTHONPATH=/app` never reached it, and `/app/bin/buttervolume` was not found.

The test suite runs the image with `docker run`, where the image configuration does apply. That is why 108 tests passed while the plugin did not start.

The entrypoint sets both variables itself now, so they hold whichever way the image is started.

## sshd would not start

Alpine's sshd refuses to run unless `/var/empty` belongs to root. `build.sh` unpacks the exported image with `tar` under the account running the build, so that directory, like the rest of the rootfs, arrives owned by that user.

Unpacking as root would be the other way round, but `docker plugin create` reads the rootfs as the user and would then no longer be allowed into `/root` or `/etc/ssh`. So the entrypoint, which already makes the host keys and fixes up `/root`, takes this directory too.

Debian never complained because its sshd uses `/run/sshd`, created at startup.

## How it was checked

- `./build.sh`, then `docker plugin enable ccomb/buttervolume:latest`: enabled, and the log shows `Serving on http://unix:/run/docker/plugins/btrfs.sock`.
- `docker volume create -d ccomb/buttervolume:latest testvol` and a container mounting it: both succeed.
- `ss -ltn` shows sshd listening on port 1122, and no error about `/var/empty` in the daemon log.