### PR TITLE
Install buttervolume where the shell and Python already look

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,10 +4,14 @@ CHANGELOG
 4.0 (unreleased)
 ****************
 
-- The plugin starts again. A docker plugin is not started from the image
-  configuration, so the ``PATH`` and ``PYTHONPATH`` the Dockerfile sets were
-  not there and ``buttervolume`` was not found. The entrypoint sets them
-  itself now, where they hold both for the plugin and for a plain container.
+- The plugin starts again, and the ``buttervolume`` command can be run inside
+  it. A docker plugin is not started from the image configuration, so the
+  ``PATH`` and ``PYTHONPATH`` the Dockerfile sets were not there and the
+  command was not found. The install now lands in ``/usr/bin`` and in the
+  interpreter's site-packages directory, where the shell and Python already
+  look, so nothing has to be set for it to be found: not for the plugin, not
+  for a plain container, and not for a ``runc exec`` into the running plugin,
+  which is how the command is called by hand.
 
 - The ssh server inside the plugin starts again. Alpine's sshd refuses to run
   unless ``/var/empty`` belongs to root, and that directory arrives owned by
@@ -45,9 +49,9 @@ CHANGELOG
   The entrypoint is plain sh instead of bash, which Alpine does not carry, and
   starts sshd directly since there is no ``service`` command.
 
-  The installed application no longer lands in the interpreter's site-packages
-  directory but in ``/app``, so the Dockerfile no longer writes a Python
-  version down anywhere and the next base system upgrade is one line.
+  The application is installed under a staging prefix in the build stage and
+  copied over ``/usr``, so the Dockerfile no longer writes a Python version
+  down anywhere and the next base system upgrade is one line.
 
   The image asks for ``e2fsprogs-extra`` by name, because busybox otherwise
   leaves its own smaller ``chattr`` and ``lsattr`` in place, and ``chattr`` is

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,11 @@ CHANGELOG
   for a plain container, and not for a ``runc exec`` into the running plugin,
   which is how the command is called by hand.
 
+  Since the install now writes where apk installs too, the Python packages come
+  from one place only: ``pytest`` and ``webtest`` are taken with the others
+  rather than from ``py3-pytest`` and ``py3-webtest``, which carried their own
+  copy of ``waitress`` next to the one buttervolume asks for.
+
 - The ssh server inside the plugin starts again. Alpine's sshd refuses to run
   unless ``/var/empty`` belongs to root, and that directory arrives owned by
   whoever unpacked the rootfs while building the plugin. The entrypoint gives

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,11 @@
+# Both stages have to carry the same interpreter: the build stage stages the
+# install under lib/pythonX.Y and the runtime copies it into /usr, where python
+# reads the directory named after its own version. Naming the base once is what
+# keeps the two equal, so an upgrade stays the one line it was.
+FROM alpine:3.22 AS base
+
 # Build stage - includes development tools
-FROM alpine:3.22 AS builder
+FROM base AS builder
 MAINTAINER Christophe Combelles. <ccomb@free.fr>
 
 RUN apk add --no-cache \
@@ -12,10 +18,10 @@ COPY buttervolume.zip /
 RUN mkdir -p /usr/src/buttervolume \
     && unzip -d /usr/src/buttervolume buttervolume.zip \
     && cd /usr/src/buttervolume \
-    && uv pip install --prefix /staging .
+    && uv pip install --prefix /staging '.[test]'
 
 # Runtime stage - minimal dependencies
-FROM alpine:3.22
+FROM base
 LABEL maintainer="Christophe Combelles <ccomb@free.fr>"
 
 # Install runtime dependencies and create directories in one layer
@@ -23,6 +29,9 @@ LABEL maintainer="Christophe Combelles <ccomb@free.fr>"
 # leaves its own smaller ones, so the copy on write flag is set by the same
 # tool as before
 # tini keeps sshd from leaving zombie processes behind
+# Python packages come from the build stage only, never from apk as well: the
+# copy below writes into the directory apk installs into, so a package owned by
+# both would end up half from one version and half from the other
 # No ssh host key is made here: the image is public, so a key baked into it
 # would be the same on every installation that pulls it. The entrypoint makes
 # them on the first start, in the directory that survives a restart
@@ -31,8 +40,6 @@ RUN apk add --no-cache \
         e2fsprogs-extra \
         ca-certificates \
         python3 \
-        py3-pytest \
-        py3-webtest \
         openssh \
         openssh-client \
         rsync \

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ COPY buttervolume.zip /
 RUN mkdir -p /usr/src/buttervolume \
     && unzip -d /usr/src/buttervolume buttervolume.zip \
     && cd /usr/src/buttervolume \
-    && uv pip install --target /app .
+    && uv pip install --prefix /staging .
 
 # Runtime stage - minimal dependencies
 FROM alpine:3.22
@@ -42,10 +42,13 @@ RUN apk add --no-cache \
     && mkdir -p /var/lib/buttervolume/snapshots \
     && mkdir -p /etc/buttervolume /root/.ssh
 
-# Copy the built application from builder stage
-COPY --from=builder /app /app
-ENV PYTHONPATH=/app
-ENV PATH="/app/bin:$PATH"
+# Copy the built application from the builder stage into the paths python and
+# the shell already look at. A docker plugin is not started from the image
+# configuration, so an install somewhere else would need a PATH and a
+# PYTHONPATH that only the entrypoint could set, and every "runc exec" into the
+# running plugin would miss them.
+COPY --from=builder /staging/bin /usr/bin
+COPY --from=builder /staging/lib /usr/lib
 
 COPY entrypoint.sh /
 ENTRYPOINT ["/entrypoint.sh"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,13 +1,5 @@
 #!/bin/sh
 
-# A docker plugin is not started from the image configuration: docker gives it
-# the default path and nothing else, so the PATH and PYTHONPATH the Dockerfile
-# sets are missing. They are set again here, where they hold both for the
-# plugin and for a plain container.
-PATH="/app/bin:$PATH"
-PYTHONPATH=/app
-export PATH PYTHONPATH
-
 SSH_PORT=${SSH_PORT:-1122}
 
 # Ensure required directories exist in the mounted volume


### PR DESCRIPTION
Running `buttervolume` inside the plugin fails:

```
$ drunc exec $ID buttervolume
exec failed: unable to start container process: exec: "buttervolume": executable file not found in $PATH
$ drunc exec $ID /app/bin/buttervolume
ModuleNotFoundError: No module named 'buttervolume'
```

A docker plugin is not started from the image configuration, so the `PATH` and
`PYTHONPATH` the Dockerfile sets never reach it. The entrypoint set them again
for its own process, which is enough for the plugin itself, but a `runc exec`
into the running plugin starts from the runtime's own environment and gets
neither. That is how the command is run by hand, as documented in the README,
so it answered that the command was not found, then that its module was not
found once called by its full path.

Rather than repeating the two variables at every call site, this installs the
application under a staging prefix in the build stage and copies it over
`/usr`. The command lands in `/usr/bin` and the package in the interpreter's
site-packages directory, both of which the shell and Python already look at,
so nothing has to be set at all and the two lines in the entrypoint go away.
The Dockerfile still writes no Python version down, so the next base system
upgrade remains one line.

Verified on a plugin built from this branch, with the README's alias unchanged:

```
$ sudo runc --root $RUNCROOT exec $ID buttervolume --version
buttervolume 4.0.0
$ docker volume create -d ccomb/buttervolume:pathfix pathfix_check
$ sudo runc --root $RUNCROOT exec $ID buttervolume snapshot pathfix_check
pathfix_check@2026-08-30T21:52:10.430275
```

`test_local.sh` passes, 98 tests, and the suite inside the built image passes,
108 tests.