### PR TITLE
Make the multi-host tests actually run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,3 +36,23 @@ jobs:
       - run: ./test_local.sh
         env:
           BUTTERVOLUME_TEST_DIR: /mnt/btrfs/test
+
+  plugin-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # Ten tests replicate over ssh, and the job above skips every one of
+      # them because ./test_local.sh says so. The plugin image carries an ssh
+      # server and its entrypoint already gives root a key to itself, so
+      # running the suite inside the image is what makes them run at all. It
+      # also runs them against the image we ship rather than against the
+      # runner.
+      - name: Run the suite inside the plugin image
+        run: |
+          set -o pipefail
+          ./test.sh 2>&1 | tee "$RUNNER_TEMP/plugin-test.log"
+          # nothing is skipped in that image today, so a skipped test means it
+          # could not give the suite what it needs, and the ssh tests would go
+          # missing again without a word
+          ! grep -q skipped "$RUNNER_TEMP/plugin-test.log"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,22 @@ jobs:
       # running the suite inside the image is what makes them run at all. It
       # also runs them against the image we ship rather than against the
       # runner.
+      # The container makes its own BTRFS filesystem on a loop device when it
+      # does not find one, and the runner hands out no loop device, so it is
+      # given one from here, the way the job above does for itself.
+      - name: Mount a BTRFS filesystem for the tests
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y btrfs-progs
+          truncate -s 2G "$RUNNER_TEMP/btrfs.img"
+          mkfs.btrfs -q "$RUNNER_TEMP/btrfs.img"
+          sudo mkdir -p /mnt/btrfs
+          sudo mount -o loop "$RUNNER_TEMP/btrfs.img" /mnt/btrfs
+          sudo chown "$(id -un)" /mnt/btrfs
+
       - name: Run the suite inside the plugin image
+        env:
+          BUTTERVOLUME_TEST_DIR: /mnt/btrfs
         run: |
           set -o pipefail
           ./test.sh 2>&1 | tee "$RUNNER_TEMP/plugin-test.log"

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,18 @@ CHANGELOG
   from one place only: ``pytest`` and ``webtest`` are taken with the others
   rather than from ``py3-pytest`` and ``py3-webtest``, which carried their own
   copy of ``waitress`` next to the one buttervolume asks for.
+- A synchronization of a volume that does not exist locally is refused
+  instead of creating one that cannot work. ``rsync`` creates the path it is
+  given, so a mistyped name left a plain directory among the subvolumes: the
+  volume list did not show it, no snapshot could be taken of it, and the
+  volume of that name could never be created afterwards, ``btrfs`` refusing a
+  subvolume where a directory already stood. Removing it meant deleting the
+  directory by hand.
+
+- The plugin starts again. A docker plugin is not started from the image
+  configuration, so the ``PATH`` and ``PYTHONPATH`` the Dockerfile sets were
+  not there and ``buttervolume`` was not found. The entrypoint sets them
+  itself now, where they hold both for the plugin and for a plain container.
 
 - The ssh server inside the plugin starts again. Alpine's sshd refuses to run
   unless ``/var/empty`` belongs to root, and that directory arrives owned by

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,14 @@ CHANGELOG
 4.0 (unreleased)
 ****************
 
+- A synchronization of a volume that does not exist locally is refused
+  instead of creating one that cannot work. ``rsync`` creates the path it is
+  given, so a mistyped name left a plain directory among the subvolumes: the
+  volume list did not show it, no snapshot could be taken of it, and the
+  volume of that name could never be created afterwards, ``btrfs`` refusing a
+  subvolume where a directory already stood. Removing it meant deleting the
+  directory by hand.
+
 - The plugin starts again, and the ``buttervolume`` command can be run inside
   it. A docker plugin is not started from the image configuration, so the
   ``PATH`` and ``PYTHONPATH`` the Dockerfile sets were not there and the
@@ -17,18 +25,6 @@ CHANGELOG
   from one place only: ``pytest`` and ``webtest`` are taken with the others
   rather than from ``py3-pytest`` and ``py3-webtest``, which carried their own
   copy of ``waitress`` next to the one buttervolume asks for.
-- A synchronization of a volume that does not exist locally is refused
-  instead of creating one that cannot work. ``rsync`` creates the path it is
-  given, so a mistyped name left a plain directory among the subvolumes: the
-  volume list did not show it, no snapshot could be taken of it, and the
-  volume of that name could never be created afterwards, ``btrfs`` refusing a
-  subvolume where a directory already stood. Removing it meant deleting the
-  directory by hand.
-
-- The plugin starts again. A docker plugin is not started from the image
-  configuration, so the ``PATH`` and ``PYTHONPATH`` the Dockerfile sets were
-  not there and ``buttervolume`` was not found. The entrypoint sets them
-  itself now, where they hold both for the plugin and for a plain container.
 
 - The ssh server inside the plugin starts again. Alpine's sshd refuses to run
   unless ``/var/empty`` belongs to root, and that directory arrives owned by

--- a/README.rst
+++ b/README.rst
@@ -667,6 +667,11 @@ The intent is to synchronize a volume between several hosts running
 containers, so you should schedule that action on each node, from all the
 other hosts.
 
+The local volume has to exist before it can be synchronized: a synchronization
+pulls files into a volume, it does not create one. Create it on the new host
+first, with ``docker volume create`` or by starting the container that uses
+it.
+
 A scheduled synchronization snapshots the volume before it pulls, and logs the
 name of that snapshot, so that a transfer stopped halfway can be recovered
 from. The one-shot ``buttervolume sync`` command does not: it writes straight

--- a/buttervolume/plugin.py
+++ b/buttervolume/plugin.py
@@ -415,10 +415,16 @@ def volume_sync(req):
     # Validate inputs
     for volume_name in volumes:
         try:
-            validate_volume_name(volume_name)
+            # rsync creates the path it is given, and what it would create
+            # here is a plain directory among the subvolumes: invisible to
+            # the list, impossible to snapshot, and standing in the way of
+            # the volume of that name ever being created. So the volume has
+            # to be there before anything is pulled into it.
+            existing_volume(volume_name)
         except ValidationError as e:
             errors.append(f"Invalid volume name {volume_name}: {str(e)}")
-            continue
+        except VolumeNotFoundError as e:
+            errors.append(str(e))
 
     for remote_host in remote_hosts:
         try:

--- a/test.py
+++ b/test.py
@@ -1692,6 +1692,77 @@ class TestCase(unittest.TestCase):
         self.assertTrue(any("replicate:backup_host" in msg for msg in log_capture.output))
         self.assertEqual(len(os.listdir(SNAPSHOTS_PATH)), nb_snaps)
 
+    def test_a_sync_refuses_a_volume_or_a_host_it_cannot_name(self):
+        """A name the sync cannot accept is named back, and nothing is pulled"""
+        with patch("buttervolume.btrfs.run_safe") as run_safe:
+            resp = jsonloads(
+                self.app.post(
+                    "/VolumeDriver.Volume.Sync",
+                    json.dumps(
+                        {
+                            "Volumes": ["../etc"],
+                            "Hosts": ["local host"],
+                            "Test": True,
+                        }
+                    ),
+                ).body
+            )
+        self.assertIn("../etc", resp["Err"])
+        self.assertIn("local host", resp["Err"])
+        run_safe.assert_not_called()
+
+    def test_a_host_that_could_not_be_pulled_from_is_named_in_the_answer(self):
+        """A host that refuses the pull stops neither the next host nor the answer"""
+        name = PREFIX_TEST_VOLUME + uuid.uuid4().hex
+        self.create_a_volume_with_a_file(name)
+        pulls = []
+
+        def pull(cmd, **kwargs):
+            pulls.append(cmd)
+            if cmd[-2].startswith("wronghost.mlf:"):
+                raise btrfs.BtrfsError("no route to host")
+            return ""
+
+        with patch("buttervolume.btrfs.run_safe", side_effect=pull):
+            resp = jsonloads(
+                self.app.post(
+                    "/VolumeDriver.Volume.Sync",
+                    json.dumps(
+                        {
+                            "Volumes": [name],
+                            "Hosts": ["wronghost.mlf", "localhost"],
+                            "Test": True,
+                        }
+                    ),
+                ).body
+            )
+        # every host was pulled from, in the order they were given
+        port = os.getenv("SSH_PORT", "1122")
+        self.assertEqual(
+            pulls,
+            [
+                [
+                    "rsync",
+                    "-v",
+                    "-r",
+                    "-a",
+                    "-z",
+                    "-h",
+                    "-P",
+                    "-e",
+                    f"ssh -p {port} -o StrictHostKeyChecking=no",
+                    f"{host}:{join(TEST_REMOTE_PATH, name)}/",
+                    join(VOLUMES_PATH, name),
+                ]
+                for host in ("wronghost.mlf", "localhost")
+            ],
+        )
+        # and only the one that failed is named, with what it said
+        self.assertIn("wronghost.mlf", resp["Err"])
+        self.assertIn("no route to host", resp["Err"])
+        self.assertNotIn("localhost", resp["Err"])
+        self.app.post("/VolumeDriver.Remove", json.dumps({"Name": name}))
+
     @unittest.skipIf(
         os.environ.get("BUTTERVOLUME_LOCAL_TEST"), "SSH not available in local test mode"
     )

--- a/test.py
+++ b/test.py
@@ -1692,6 +1692,29 @@ class TestCase(unittest.TestCase):
         self.assertTrue(any("replicate:backup_host" in msg for msg in log_capture.output))
         self.assertEqual(len(os.listdir(SNAPSHOTS_PATH)), nb_snaps)
 
+    def test_a_sync_refuses_a_volume_that_is_not_there(self):
+        """Nothing is pulled into a name no volume answers to"""
+        name = PREFIX_TEST_VOLUME + uuid.uuid4().hex
+        with patch("buttervolume.btrfs.run_safe") as run_safe:
+            resp = jsonloads(
+                self.app.post(
+                    "/VolumeDriver.Volume.Sync",
+                    json.dumps(
+                        {
+                            "Volumes": [name],
+                            "Hosts": ["localhost"],
+                            "Test": True,
+                        }
+                    ),
+                ).body
+            )
+        self.assertIn("no such volume", resp["Err"])
+        run_safe.assert_not_called()
+        # rsync would have made a plain directory there, which the list cannot
+        # show, no snapshot can take, and the volume of that name would then
+        # never be created again
+        self.assertFalse(os.path.exists(join(VOLUMES_PATH, name)))
+
     def test_a_sync_refuses_a_volume_or_a_host_it_cannot_name(self):
         """A name the sync cannot accept is named back, and nothing is pulled"""
         with patch("buttervolume.btrfs.run_safe") as run_safe:
@@ -1716,8 +1739,13 @@ class TestCase(unittest.TestCase):
         name = PREFIX_TEST_VOLUME + uuid.uuid4().hex
         self.create_a_volume_with_a_file(name)
         pulls = []
+        run_safe = btrfs.run_safe
 
         def pull(cmd, **kwargs):
+            # the route also asks btrfs whether the volume is there, and that
+            # question deserves its real answer
+            if cmd[0] != "rsync":
+                return run_safe(cmd, **kwargs)
             pulls.append(cmd)
             if cmd[-2].startswith("wronghost.mlf:"):
                 raise btrfs.BtrfsError("no route to host")

--- a/test.sh
+++ b/test.sh
@@ -27,7 +27,24 @@ else
     echo "Clean build for version $VERSION"
     docker build --build-arg VERSION=$VERSION -t ccomb/buttervolume_test:$VERSION . --no-cache
 fi
-test="sudo docker run --rm --privileged -v /var/lib/docker:/var/lib/docker -v $PWD:/usr/src/buttervolume -w /usr/src/buttervolume ccomb/buttervolume_test:HEAD test"
+# The tests need a BTRFS filesystem, and the container makes one on a loop
+# device when it does not find one. A kernel that hands out no loop device
+# leaves them with nothing, so BUTTERVOLUME_TEST_DIR names a BTRFS directory
+# to work in instead, as it does for ./test_local.sh.
+testdir=""
+if [ -n "$BUTTERVOLUME_TEST_DIR" ]; then
+    # It has to be where the filesystem is mounted, not a directory inside it.
+    # Giving a subdirectory hides the rest of the tree from the container, and
+    # "btrfs receive" then cannot find the parent it was given, so the two
+    # tests of an incremental transfer fail without saying why.
+    if ! mountpoint -q "$BUTTERVOLUME_TEST_DIR"; then
+        echo "❌ BUTTERVOLUME_TEST_DIR must be where a BTRFS filesystem is mounted"
+        exit 1
+    fi
+    mkdir -p "$BUTTERVOLUME_TEST_DIR"/{volumes,snapshots,received}
+    testdir="-v $BUTTERVOLUME_TEST_DIR:/var/lib/buttervolume"
+fi
+test="sudo docker run --rm --privileged $testdir -v /var/lib/docker:/var/lib/docker -v $PWD:/usr/src/buttervolume -w /usr/src/buttervolume ccomb/buttervolume_test:HEAD test"
 $test
 echo "#############################"
 echo "You can run tests again with:"

--- a/test.sh
+++ b/test.sh
@@ -16,8 +16,8 @@ if [ "$VERSION" == "" ]; then
     echo "Testing version $VERSION"
     echo "You can test another version with: ./test.sh <VERSION>"
     echo "#####################"
-    git archive -o buttervolume.zip $VERSION
 fi
+git archive -o buttervolume.zip $VERSION
 
 # Use cache for development (HEAD), clean build for specific versions
 if [ "$1" == "" ]; then
@@ -44,7 +44,7 @@ if [ -n "$BUTTERVOLUME_TEST_DIR" ]; then
     mkdir -p "$BUTTERVOLUME_TEST_DIR"/{volumes,snapshots,received}
     testdir="-v $BUTTERVOLUME_TEST_DIR:/var/lib/buttervolume"
 fi
-test="sudo docker run --rm --privileged $testdir -v /var/lib/docker:/var/lib/docker -v $PWD:/usr/src/buttervolume -w /usr/src/buttervolume ccomb/buttervolume_test:HEAD test"
+test="sudo docker run --rm --privileged $testdir -v /var/lib/docker:/var/lib/docker -v $PWD:/usr/src/buttervolume -w /usr/src/buttervolume ccomb/buttervolume_test:$VERSION test"
 $test
 echo "#############################"
 echo "You can run tests again with:"

--- a/test.sh
+++ b/test.sh
@@ -27,7 +27,7 @@ else
     echo "Clean build for version $VERSION"
     docker build --build-arg VERSION=$VERSION -t ccomb/buttervolume_test:$VERSION . --no-cache
 fi
-test="sudo docker run -it --rm --privileged -v /var/lib/docker:/var/lib/docker -v $PWD:/usr/src/buttervolume -w /usr/src/buttervolume ccomb/buttervolume_test:HEAD test"
+test="sudo docker run --rm --privileged -v /var/lib/docker:/var/lib/docker -v $PWD:/usr/src/buttervolume -w /usr/src/buttervolume ccomb/buttervolume_test:HEAD test"
 $test
 echo "#############################"
 echo "You can run tests again with:"


### PR DESCRIPTION
The ten tests that go over ssh, including the only one that gives a
synchronization several hosts, ran nowhere automatically. The continuous
integration only runs `./test_local.sh`, which sets `BUTTERVOLUME_LOCAL_TEST`,
and that flag is exactly what skips them. They passed on a developer machine
and were absent from every pull request.

**The suite now runs in the plugin image as well.** The image already carries
an ssh server, and its entrypoint already gives root a key to itself for
exactly this purpose, so a job that builds the image and runs the suite inside
it brings the ten tests back for the price of the build, and runs them against
the image we ship rather than against the runner. Nothing is skipped in that
image today, so the job refuses a run that skips anything: a machine that could
not give the suite what it needs would otherwise leave the same hole behind a
green tick. The `-it` had to go from `test.sh` first, since the container reads
nothing from a keyboard and asking docker for a terminal fails wherever there
is none.

The runner then showed what a developer machine hides: the container cannot
make its own BTRFS filesystem there, `losetup` finding no loop device to hand
out, and sixty three tests failed rather than ran. So the filesystem is made on
the runner, where that works, and handed to the container.
`BUTTERVOLUME_TEST_DIR` names it, as it already does for `./test_local.sh`. It
has to be where the filesystem is mounted and not a directory inside it: a
subdirectory hides the rest of the tree from the container, and `btrfs receive`
then cannot find the parent of an incremental transfer. The script says so
rather than letting those two tests fail without a reason.

**Two tests cover what a synchronization does with several hosts.** One checks
that a volume name or a hostname the route cannot accept is named back and that
nothing is transferred. The other gives it two hosts where the first refuses:
both pulls are issued, in the order given, and only the failing host is named
in the answer. They replace `btrfs.run_safe` rather than call rsync, so they
say what the route decides without needing a second machine, and they run in
both modes of the suite.

**A synchronization of a volume that is not there is now refused.** Writing
those tests is what showed it: the route built the local path from the name
alone, and rsync creates the path it is given. A mistyped name left a plain
directory among the subvolumes, filled with the files of the remote host. The
volume list did not show it, no snapshot could be taken of it, and the volume
of that name could never be created afterwards, btrfs refusing a subvolume
where a directory already stands. Nothing in the plugin could remove it
either, only a `rm -rf` by hand. The route now asks for the volume the way its
neighbours do. A host joining the cluster creates its volume before it
synchronizes, which the manual says now.

No cluster, no virtual machines: what those would add here is topology, and the
logic under test is names, paths and the order of a loop. The transport itself
is already exercised against localhost.

The local suite goes from 98 to 101 passed, still 10 skipped. The suite in the
image goes from 108 to 111 passed, nothing skipped, on the runner as well as
on a developer machine.
