### PR TITLE
Explain how to leave anybox/buttervolume behind

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,11 @@ CHANGELOG
 4.0 (unreleased)
 ****************
 
+- The manual explains how to leave ``anybox/buttervolume`` behind: an in
+  place upgrade of the plugin that keeps its name and touches no volume, or a
+  snapshot and restore of each volume under the new name, and how to move
+  the volumes to another host without either.
+
 - A synchronization of a volume that does not exist locally is refused
   instead of creating one that cannot work. ``rsync`` creates the path it is
   given, so a mistyped name left a plain directory among the subvolumes: the

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -257,7 +257,10 @@ CHANGELOG
 - Updated dependencies
 - Fixed a freeze in front mode (#47)
 - Fixed critical #51 `schedule not working` 
-- Allow using volumes created with legacy plugin anybox/buttervolume (fix #52)
+- The ``buttervolume`` command run from the host finds the plugin when it is
+  installed under its former name ``anybox/buttervolume`` (#52). The volumes
+  themselves stay bound to the driver name they were created with; the manual
+  says how to move them.
 - Fixed deletion of old sent snapshots
 - Added support for compression (fix #36)
 - A failing BTRFS command is now always reported the same way, naming the command

--- a/README.rst
+++ b/README.rst
@@ -192,6 +192,89 @@ You must force disable it before reinstalling it (as explained in the docker doc
     docker plugin install ccomb/buttervolume
 
 
+Migrating from anybox/buttervolume
+**********************************
+
+The plugin was published as ``anybox/buttervolume`` up to version 3.12. A host
+still running it has nothing to move: both plugins keep the volumes, the
+snapshots, the schedule and the ssh keys in the same places under
+``/var/lib/buttervolume``. What stands in the way is the name. Docker records
+the driver of each volume when the volume is created, and that name cannot be
+changed afterwards, so a volume created with ``anybox/buttervolume:latest``
+works only with a plugin of that name.
+
+This leaves two ways, and the second one starts with the first.
+
+**Keep the name, replace the code.** Docker can upgrade a plugin in place: the
+plugin keeps its name and its id, and gets the rootfs of another image. The
+volumes are not touched, the containers only have to be stopped for the
+duration of the upgrade, and nothing changes in the compose files::
+
+    set -e
+    old=anybox/buttervolume:latest
+    new=ccomb/buttervolume:latest
+    volumes=$(docker volume ls -q -f driver=$old)
+    containers=$(for v in $volumes; do docker ps -q -f volume=$v; done | sort -u)
+    [ -z "$containers" ] || docker stop $containers
+    docker plugin disable -f $old
+    docker plugin upgrade --skip-remote-check --grant-all-permissions $old $new
+    docker plugin enable $old
+    [ -z "$containers" ] || docker start $containers
+
+``--skip-remote-check`` is what allows the new image to carry another name
+than the plugin it replaces. From there the plugin is the current one under
+its old name, and the ``buttervolume`` command finds it: in the functions of
+`Install and run as a user`_, replace ``ccomb/buttervolume:latest`` with
+``anybox/buttervolume:latest``.
+
+**Take the new name.** Once the code is the current one, the volumes can be
+recreated under the new driver name, through a snapshot: a volume is deleted
+with its driver, so each one is snapshotted first, and restored under the new
+plugin afterwards. A volume referenced by a container cannot be deleted, even
+a stopped one, so the containers go too, and are recreated at the end with the
+new driver name in their configuration. The snapshots stay where they are and
+what they hold is not copied: the restored volume is a snapshot of the
+snapshot, so this costs neither time nor space::
+
+    set -e
+    old=anybox/buttervolume:latest
+    new=ccomb/buttervolume:latest
+    RUNCROOT=/run/docker/runtime-runc/plugins.moby/ # or /run/docker/plugins/runtime-root/plugins.moby/
+    bv () { sudo runc --root $RUNCROOT exec $(docker plugin inspect -f '{{.Id}}' $1) buttervolume "${@:2}"; }
+    volumes=$(docker volume ls -q -f driver=$old)
+    containers=$(for v in $volumes; do docker ps -aq -f volume=$v; done | sort -u)
+    bv $old scheduled pause
+    for v in $volumes; do bv $old snapshot $v; done
+    [ -z "$containers" ] || docker rm -f $containers
+    for v in $volumes; do docker volume rm $v; done
+    docker plugin disable $old
+    docker plugin rm $old
+    docker plugin install --grant-all-permissions $new
+    for v in $volumes; do bv $new restore $v; done
+    for v in $volumes; do docker volume create -d $new $v; done
+    bv $new scheduled resume
+
+Then change the driver of the volumes in the compose files, and start the
+containers again. With docker compose, leave out the ``docker volume create``
+line: compose refuses a volume it did not create itself, and creates it on
+``docker compose up`` over the subvolume the restore has just put in place.
+
+**Moving to another host** does not need either of the above on the old host:
+the snapshot goes through ``btrfs send`` over ssh, which the old plugin speaks
+as well. Set up the ssh keys as described in `Replicate a snapshot to another
+host`_, then on the old host, with ``bv`` defined as above::
+
+    for v in $volumes; do bv $old send <newhost> $(bv $old snapshot $v); done
+
+and on the new host, which has never seen these volumes::
+
+    for v in $volumes; do bv $new restore $v; docker volume create -d $new $v; done
+
+The first send to a host carries the whole volume, since nothing over there
+can serve as a parent; the following ones carry the difference. The old
+snapshots stay on the old host, and nothing depends on them.
+
+
 Using buttervolume CLI in a container
 *************************************
 

--- a/README.rst
+++ b/README.rst
@@ -195,7 +195,7 @@ You must force disable it before reinstalling it (as explained in the docker doc
 Migrating from anybox/buttervolume
 **********************************
 
-The plugin was published as ``anybox/buttervolume`` up to version 3.12. A host
+The plugin was published as ``anybox/buttervolume`` up to version 3.10. A host
 still running it has nothing to move: both plugins keep the volumes, the
 snapshots, the schedule and the ssh keys in the same places under
 ``/var/lib/buttervolume``. What stands in the way is the name. Docker records
@@ -230,11 +230,14 @@ its old name, and the ``buttervolume`` command finds it: in the functions of
 **Take the new name.** Once the code is the current one, the volumes can be
 recreated under the new driver name, through a snapshot: a volume is deleted
 with its driver, so each one is snapshotted first, and restored under the new
-plugin afterwards. A volume referenced by a container cannot be deleted, even
-a stopped one, so the containers go too, and are recreated at the end with the
-new driver name in their configuration. The snapshots stay where they are and
-what they hold is not copied: the restored volume is a snapshot of the
-snapshot, so this costs neither time nor space::
+plugin afterwards. The containers are stopped before the snapshot, so that it
+holds a volume nobody is writing to. A volume referenced by a container cannot
+be deleted, even a stopped one, so the containers go too, and are recreated at
+the end with the new driver name in their configuration. The snapshots stay
+where they are and what they hold is not copied: the restored volume is a
+snapshot of the snapshot, so this costs neither time nor space. An ``SSH_PORT``
+set on the plugin goes away with it, so it is read first and given to the new
+one::
 
     set -e
     old=anybox/buttervolume:latest
@@ -243,13 +246,15 @@ snapshot, so this costs neither time nor space::
     bv () { sudo runc --root $RUNCROOT exec $(docker plugin inspect -f '{{.Id}}' $1) buttervolume "${@:2}"; }
     volumes=$(docker volume ls -q -f driver=$old)
     containers=$(for v in $volumes; do docker ps -aq -f volume=$v; done | sort -u)
+    port=$(docker plugin inspect -f '{{range .Settings.Env}}{{println .}}{{end}}' $old | grep ^SSH_PORT=)
+    [ -z "$containers" ] || docker stop $containers
     bv $old scheduled pause
     for v in $volumes; do bv $old snapshot $v; done
-    [ -z "$containers" ] || docker rm -f $containers
+    [ -z "$containers" ] || docker rm $containers
     for v in $volumes; do docker volume rm $v; done
-    docker plugin disable $old
+    docker plugin disable -f $old
     docker plugin rm $old
-    docker plugin install --grant-all-permissions $new
+    docker plugin install --grant-all-permissions $new $port
     for v in $volumes; do bv $new restore $v; done
     for v in $volumes; do docker volume create -d $new $v; done
     bv $new scheduled resume
@@ -262,12 +267,17 @@ line: compose refuses a volume it did not create itself, and creates it on
 **Moving to another host** does not need either of the above on the old host:
 the snapshot goes through ``btrfs send`` over ssh, which the old plugin speaks
 as well. Set up the ssh keys as described in `Replicate a snapshot to another
-host`_, then on the old host, with ``bv`` defined as above::
+host`_, then on the old host, with ``old``, ``bv`` and ``volumes`` defined as
+in the script above::
 
-    for v in $volumes; do bv $old send <newhost> $(bv $old snapshot $v); done
+    newhost=node2
+    for v in $volumes; do bv $old send $newhost $(bv $old snapshot $v); done
 
-and on the new host, which has never seen these volumes::
+and on the new host, which has never seen these volumes, with ``bv`` defined
+the same way and ``volumes`` naming what was sent::
 
+    new=ccomb/buttervolume:latest
+    volumes="www db"
     for v in $volumes; do bv $new restore $v; docker volume create -d $new $v; done
 
 The first send to a host carries the whole volume, since nothing over there


### PR DESCRIPTION
A host still running the plugin as `anybox/buttervolume` has nothing to move: both plugins keep the volumes, snapshots, schedule and ssh keys in the same places under `/var/lib/buttervolume`. What stands in the way is the driver name, which Docker records on each volume and never changes.

This adds a section to the manual with a script for each way out:

- an in place `docker plugin upgrade --skip-remote-check`, which keeps the plugin name and id and touches no volume. Checked here on a disabled throwaway plugin: the plugin reference switches to `ccomb/buttervolume:latest` while the name stays.
- a snapshot and restore of each volume under the new driver name, for a host that wants to see `ccomb` in `docker volume ls`.

It also explains that moving the volumes to another host needs neither on the old host, since the old plugin already speaks `btrfs send` over ssh, and that the first send to a host is a whole one by itself.

The second and third scripts were not run: they rely on commands already documented in "Migrate to version 3" and on the send and restore commands. The RST parses and the scripts pass `bash -n`.