### PR TITLE
Say what upgrading to version 4 changes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,16 @@ CHANGELOG
   said the old ``2h:2h`` spelling was refused everywhere, where in truth only
   the ``purge`` command refuses it and a schedule still runs it.
 
+- The manual now has a "Migrate to version 4" section, saying what this
+  version changes for a host running version 3. The entries below each
+  describe one change, and none of them says what an administrator has to
+  decide before upgrading: that every ``replicate:`` line already written
+  starts moving its volume between hosts, that a replication host which is
+  down then keeps a container from starting, that the first mount of a volume
+  this host never received may need more than the thirty seconds Docker
+  gives it, that the ssh host keys change, and that the first restart runs
+  every scheduled job once.
+
 - The manual explains how to leave ``anybox/buttervolume`` behind: an in
   place upgrade of the plugin that keeps its name and touches no volume, or a
   snapshot and restore of each volume under the new name, and how to move

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,14 +18,16 @@ CHANGELOG
   the ``purge`` command refuses it and a schedule still runs it.
 
 - The manual now has a "Migrate to version 4" section, saying what this
-  version changes for a host running version 3. The entries below each
-  describe one change, and none of them says what an administrator has to
-  decide before upgrading: that every ``replicate:`` line already written
-  starts moving its volume between hosts, that a replication host which is
-  down then keeps a container from starting, that the first mount of a volume
-  this host never received may need more than the thirty seconds Docker
-  gives it, that the ssh host keys change, and that the first restart runs
-  every scheduled job once.
+  version changes for a host running version 3. What it holds is said in the
+  entries below too, but scattered over five of them, each written from the
+  point of view of the change it describes rather than of the administrator
+  about to upgrade. The section gathers them in the order one has to act:
+  every ``replicate:`` line already written starts moving its volume between
+  hosts, and a replication host which is down then keeps a container from
+  starting; the first mount of a volume this host never received may need
+  more than the thirty seconds Docker gives it; the ssh host keys change; a
+  send can now be refused; an unknown volume option is refused; and the first
+  restart runs every scheduled job once.
 
 - The manual explains how to leave ``anybox/buttervolume`` behind: an in
   place upgrade of the plugin that keeps its name and touches no volume, or a

--- a/README.rst
+++ b/README.rst
@@ -1170,10 +1170,16 @@ Two consequences are worth knowing before rather than after:
       docker plugin install --disable ccomb/buttervolume
       docker plugin enable --timeout 600 ccomb/buttervolume
 
-For a volume that must keep the old behaviour, pause its line before you
-upgrade, or delete it::
+There is no setting that keeps the periodic send without the handover: the
+two are the same line, and a volume either replicates the version 4 way or
+does not replicate. So a volume that must not change hands has its line
+paused before you upgrade, or deleted, and stops being replicated at all::
 
     buttervolume schedule replicate:node2 pause myvolume
+
+The copy on ``node2`` then ages where it stands. Take a snapshot of the
+volume and send it by hand, with ``buttervolume replicate node2 myvolume``,
+for as long as the line stays paused.
 
 **The ssh host keys change.** Up to 3.13 they were built into the image, so
 every installation of a given tag presented the same identity, and anyone could
@@ -1189,9 +1195,12 @@ recording a key that is now public. Clear it::
 
     ssh-keygen -R '[node2]:1122' -f /var/lib/buttervolume/ssh/known_hosts
 
-A host where you wired a stricter ssh configuration of your own, under
-``/var/lib/buttervolume/ssh/config``, will refuse to connect until you do.
-Restart the Docker daemon after changing anything under ``ssh/``.
+Clearing it takes effect at once, and needs no restart: each transfer starts
+a new ``ssh``, which reads the file then. Note that writing
+``StrictHostKeyChecking yes`` in ``/var/lib/buttervolume/ssh/config`` does not
+make the plugin stricter, and never has: ssh keeps the first value it is given
+for a parameter, and the plugin passes the option on the command line, which
+comes before that file.
 
 **A send can now be refused.** Before sending, the remote host is asked which
 snapshot of the volume last appeared there. When this host has never seen it,
@@ -1217,8 +1226,9 @@ breaks, and ``buttervolume scheduled --auto-convert-old-patterns`` rewrites
 them.
 
 **Python 3.11 at least**, if you install Buttervolume as a Python distribution
-rather than as a plugin. The plugin image has been carrying 3.11 or later all
-along, so this concerns a local installation only.
+rather than as a plugin. The plugin image has carried 3.11 or later since 3.12,
+where it moved from Debian bullseye to Debian 12, so this concerns a local
+installation only.
 
 
 Migrate to version 3

--- a/README.rst
+++ b/README.rst
@@ -1140,6 +1140,87 @@ find your previous docker volumes back::
     rm /var/lib/docker/btrfs.img
 
 
+Migrate to version 4
+********************
+
+Version 4 keeps the volumes, the snapshots, the schedule and the ssh keys where
+version 3 left them, so upgrading the plugin is enough and there is nothing to
+move. What changes is what some of it now means, and one of those changes can
+keep a container from starting. Read this before upgrading a host that
+replicates.
+
+**A** ``replicate:`` **line now moves the volume, and not only its snapshots.**
+This is the one to think about. Up to 3.13, such a line sent a snapshot to
+another host every period, and nothing else ever happened. From version 4, the
+volume follows its container: the first container to start takes what the other
+host holds, and the last one to stop sends what this host wrote (see `Move an
+application between hosts`_). Every ``replicate:`` line already in
+``schedule.csv`` changes meaning the day you upgrade, on both hosts.
+
+Two consequences are worth knowing before rather than after:
+
+- a replication host that is down **stops the mount**, so the container does
+  not start. That is deliberate, and `Move an application between hosts`_ says
+  why, but it is a host that used to start regardless;
+- the first container of a volume this host has never received receives the
+  whole volume, and Docker gives a plugin thirty seconds to answer a mount.
+  Give it more patience, or create the volume and let a scheduled round go by
+  before starting the container::
+
+      docker plugin install --disable ccomb/buttervolume
+      docker plugin enable --timeout 600 ccomb/buttervolume
+
+For a volume that must keep the old behaviour, pause its line before you
+upgrade, or delete it::
+
+    buttervolume schedule replicate:node2 pause myvolume
+
+**The ssh host keys change.** Up to 3.13 they were built into the image, so
+every installation of a given tag presented the same identity, and anyone could
+read the private keys out of the public image. Treat the keys published up to
+3.13 as known to everyone. Version 4 makes its own on the first start, in
+``/var/lib/buttervolume/ssh/``, and keeps them from one restart to the next.
+
+Replication itself keeps working across the change, because Buttervolume passes
+``StrictHostKeyChecking=no`` on every ssh call, and that setting lets a
+connection to a host whose key changed proceed. What is left behind is a stale
+entry in the ``known_hosts`` of every host that replicated to the upgraded one,
+recording a key that is now public. Clear it::
+
+    ssh-keygen -R '[node2]:1122' -f /var/lib/buttervolume/ssh/known_hosts
+
+A host where you wired a stricter ssh configuration of your own, under
+``/var/lib/buttervolume/ssh/config``, will refuse to connect until you do.
+Restart the Docker daemon after changing anything under ``ssh/``.
+
+**A send can now be refused.** Before sending, the remote host is asked which
+snapshot of the volume last appeared there. When this host has never seen it,
+the volume over there has moved on without this one, and the send is refused
+rather than burying that history. A host coming back from a crash, and a host
+where somebody restored an old snapshot by hand, will say so at every round
+until you receive that snapshot or delete it over there. The error names it.
+
+**An unknown volume option is now refused.** It used to be ignored. A compose
+file or a ``docker volume create`` carrying an option that is neither
+``copyonwrite``, ``compression`` nor an action to schedule will fail to create
+the volume, where it used to create it and say nothing.
+
+**The first restart runs every scheduled job once.** The scheduler now
+remembers in ``/var/lib/buttervolume/lastruns.csv`` when each job last ran,
+instead of forgetting it when the daemon stops. There is no such file the day
+you upgrade, so every job is due: expect one purge and one replication of each
+volume shortly after the restart, and the normal periods afterwards.
+
+**Check your purge patterns.** ``buttervolume scheduled`` now reports a pattern
+written as ``2h:2h`` as deprecated. It still purges as ``2h`` does, so nothing
+breaks, and ``buttervolume scheduled --auto-convert-old-patterns`` rewrites
+them.
+
+**Python 3.11 at least**, if you install Buttervolume as a Python distribution
+rather than as a plugin. The plugin image has been carrying 3.11 or later all
+along, so this concerns a local installation only.
+
+
 Migrate to version 3
 ********************
 


### PR DESCRIPTION
Stacked on #122.

The changelog describes each change of this version one by one, which is what a changelog is for, and none of its entries answers the question an administrator asks before upgrading a host that replicates: what do I have to decide first.

The answer is mostly one thing. A `replicate:` line used to send a snapshot every period and do nothing else; from this version the volume follows its container, so **every line already written changes meaning the day the plugin is upgraded**, on both hosts, and a replication host that is down then keeps a container from starting. Someone who learns that from the container that will not start has already stopped the application.

The new "Migrate to version 4" section says that first, with the two ways out (pause the line, or give Docker a longer mount timeout), then the smaller surprises:

- the ssh host keys change, and the ones published up to 3.13 are public;
- a send can now be refused when the remote history moved on without this host;
- an unknown volume option is refused where it used to be ignored;
- the first restart runs every scheduled job once, there being no `lastruns.csv` yet;
- a local install now needs Python 3.11.

Each claim was checked against the code rather than against the changelog, and one came out differently: the ssh paragraph. Every ssh call already passes `StrictHostKeyChecking=no`, which per `ssh_config(5)` lets a connection to a host whose key changed proceed, so replication does not break across the upgrade. The section says that, and points at the stale `known_hosts` entry recording a now-public key as the thing actually left to do.

RST parses with no warning on both files, cross-references resolve, `test_local.sh`: 129 passed, 11 skipped.