### PR TITLE
Number the purge timeframes on the calendar rather than on the age

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,15 @@ CHANGELOG
 4.0 (unreleased)
 ****************
 
+- A purge numbers its timeframes on the calendar instead of on the age of the
+  snapshots. The bounds of a timeframe were counted from the moment the purge
+  ran, so they moved from one run to the next and the snapshot spared in a
+  timeframe was rarely the same one twice. They are now counted from the 1st of
+  January 1970, in local time, so a one day timeframe starts at midnight, and
+  the snapshot spared is the oldest one of its timeframe. A purge pattern also
+  reads the date of a snapshot to order them, rather than the spelling of its
+  name, which the ``DTFORMAT`` setting can make unsortable.
+
 - The manual no longer describes things the code stopped doing. Its manual
   setup created two of the four directories the plugin expects, so whoever
   preferred it to ``buttervolume init`` got a plugin with nowhere to put a

--- a/README.rst
+++ b/README.rst
@@ -684,6 +684,14 @@ Here are a few examples of retention patterns:
     deprecated, and ``buttervolume scheduled --auto-convert-old-patterns``
     rewrites it.
 
+Inside a pattern, a timeframe is a slice of the calendar and not a slice of the
+age. A one day timeframe starts at midnight, a four hour one at 0:00, 4:00, 8:00
+and so on, and a one week one on a Thursday, because timeframes are counted from
+the 1st of January 1970. The snapshot kept in a timeframe is the oldest one it
+holds, and it is still the same one at the next purge. Counted from the moment
+the purge runs instead, every boundary would move between two runs and the purge
+would spare a different snapshot each time.
+
 Whatever the pattern says, a purge never deletes what a replication needs: the
 trace of the last send to a host, named ``<volume>@<datetime>@<host>``, and the
 snapshot it was made from, which is the parent the next incremental send is

--- a/buttervolume/purge.py
+++ b/buttervolume/purge.py
@@ -84,7 +84,6 @@ def compute_purges(snapshots, pattern, now, dtformat):
     Never the trace of a send, nor the snapshot it was made from: whatever
     the pattern says, a replication keeps the parent its next send needs.
     """
-    snapshots = sorted(snapshots)
     # a purge does not delete what a send still needs: the trace of a send, and
     # the snapshot it was made from, which is the parent the next incremental
     # send is built on. Both are taken out of the answer rather than out of the
@@ -126,13 +125,20 @@ def compute_purges(snapshots, pattern, now, dtformat):
                 # Only 70 and 90 are inside the age_segment (60, 180)
                 if age > age_segment[0] < max_age or age < age_segment[1]:
                     continue
+                # Past the oldest duration of the pattern everything dies, and
+                # without claiming a timeframe: a timeframe is a slice of the
+                # calendar, so it can hold both a snapshot too old to keep and
+                # a younger one still inside the segment, and the second would
+                # be deleted as a duplicate of the first with nothing spared.
+                if age > max_age:
+                    purge_list.append(s)
+                    continue
                 # Now get the timeframe number of the snapshot: the slice of
                 # the calendar it was taken in, as wide as this segment steps,
                 # and not the slice its age falls in today.
-                timeframe = (taken - EPOCH) // timedelta(minutes=1) // age_segment[1]
+                timeframe = (taken - EPOCH) // timedelta(minutes=age_segment[1])
                 # delete if we already had a snapshot in the same timeframe
-                # or if the snapshot is very old
-                if timeframe == last_timeframe or age > max_age:
+                if timeframe == last_timeframe:
                     purge_list.append(s)
                 last_timeframe = timeframe
     return [s for s in purge_list if s not in needed]

--- a/buttervolume/purge.py
+++ b/buttervolume/purge.py
@@ -17,6 +17,7 @@ date format arrives as an argument, as it does for a snapshot name.
 
 import logging
 from dataclasses import dataclass
+from datetime import datetime, timedelta
 
 from buttervolume import ValidationError
 from buttervolume.names import Snapshot, parsed
@@ -24,6 +25,11 @@ from buttervolume.names import Snapshot, parsed
 log = logging.getLogger()
 
 UNITS = {"m": 1, "h": 60, "d": 60 * 24, "w": 60 * 24 * 7, "y": 60 * 24 * 365}
+
+# Timeframes are counted from here, in wall clock minutes: a day wide timeframe
+# starts at midnight, an hour wide one on the round hour, and a week wide one on
+# a Thursday, since that is what the 1st of January 1970 was.
+EPOCH = datetime(1970, 1, 1)
 
 
 @dataclass(frozen=True)
@@ -70,6 +76,11 @@ class Pattern:
 def compute_purges(snapshots, pattern, now, dtformat):
     """Return the list of snapshots this pattern condemns, at this moment.
 
+    Inside a segment the pattern keeps one snapshot per timeframe, and that
+    timeframe is counted from the epoch, on the moment the snapshot was taken.
+    Counting it on the age would move every boundary at every run, and the
+    snapshot spared in a timeframe would not be the same one twice.
+
     Never the trace of a send, nor the snapshot it was made from: whatever
     the pattern says, a replication keeps the parent its next send needs.
     """
@@ -87,39 +98,41 @@ def compute_purges(snapshots, pattern, now, dtformat):
     ages = list(reversed(pattern.minutes))
     purge_list = []
     max_age = ages[0]
-    # Age of the snapshots in minutes.
-    # Example : [30, 70, 90, 150, 210, ..., 4000]
-    snapshots_age = []
-    valid_snapshots = []
+    # Each snapshot with the moment it was taken and its age in minutes.
+    # Example : [(datetime(2026, 8, 26, 11, 30), "www@...", 30), ...]
+    # Ordered on that moment and not on the name, because the date format is a
+    # setting and nothing promises it sorts like a date.
+    dated = []
     for s in snapshots:
         try:
-            age = now - Snapshot.parse(s).taken_at(dtformat)
+            taken = Snapshot.parse(s).taken_at(dtformat)
         except (ValidationError, ValueError):
             # a purge does not delete what it cannot date
             log.info("Skipping purge of %s with invalid date format", s)
             continue
-        snapshots_age.append(int(age.total_seconds()) / 60)
-        valid_snapshots.append(s)
+        dated.append((taken, s, int((now - taken).total_seconds()) / 60))
+    dated.sort()
     # A single specifier ("2h" -> [120]) deletes everything past the threshold
     if len(ages) == 1:
-        purge_list = [s for s, age in zip(valid_snapshots, snapshots_age) if age > ages[0]]
+        purge_list = [s for _, s, age in dated if age > ages[0]]
     else:
         # Several specifiers ("2h:1d:1w" -> [10080, 1440, 120]) keep one snapshot
         # per timeframe inside each segment.
         # age segments = [(10080, 1440), (1440, 120)]
         for age_segment in [(ages[i], ages[i + 1]) for i, _ in enumerate(ages[:-1])]:
-            last_timeframe = -1
-            for i, age in enumerate(snapshots_age):
+            last_timeframe = None
+            for taken, s, age in dated:
                 # if the age is outside the age_segment, delete nothing.
                 # Only 70 and 90 are inside the age_segment (60, 180)
                 if age > age_segment[0] < max_age or age < age_segment[1]:
                     continue
-                # Now get the timeframe number of the snapshot.
-                # Ages 70 and 90 are in the same timeframe (70//60 == 90//60)
-                timeframe = age // age_segment[1]
+                # Now get the timeframe number of the snapshot: the slice of
+                # the calendar it was taken in, as wide as this segment steps,
+                # and not the slice its age falls in today.
+                timeframe = (taken - EPOCH) // timedelta(minutes=1) // age_segment[1]
                 # delete if we already had a snapshot in the same timeframe
                 # or if the snapshot is very old
                 if timeframe == last_timeframe or age > max_age:
-                    purge_list.append(valid_snapshots[i])
+                    purge_list.append(s)
                 last_timeframe = timeframe
     return [s for s in purge_list if s not in needed]

--- a/test.py
+++ b/test.py
@@ -1850,20 +1850,10 @@ class TestCase(unittest.TestCase):
         self.assertEqual(jsonloads(resp.body), {"Err": ""})
         self.assertEqual(len(os.listdir(SNAPSHOTS_PATH)), nb_snaps)
 
-        cleanup_snapshots()
-        self.create_20_hourly_snapshots(name)
-        # run the purge with a more complex save pattern (2h:4h:8h:16h)
-        nb_snaps = len(os.listdir(SNAPSHOTS_PATH))
-        resp = self.app.post(
-            "/VolumeDriver.Snapshots.Purge",
-            json.dumps({"Name": name, "Pattern": "2h:4h:8h:16h"}),
-        )
-        self.assertEqual(jsonloads(resp.body), {"Err": ""})
-        # check we deleted 14 snapshots
-        self.assertEqual(len(os.listdir(SNAPSHOTS_PATH)), nb_snaps - 14)
-
-        cleanup_snapshots()
-        self.create_20_hourly_snapshots(name)
+        # What a pattern of several components keeps is counted in
+        # TestWhatAPurgeCondemns, on a frozen clock: the timeframes are slices
+        # of the calendar now, so the count here would depend on the hour the
+        # test suite happens to run at.
 
         # Test that deprecated duplicate patterns are rejected with helpful message
         resp = self.app.post(
@@ -1906,15 +1896,6 @@ class TestCase(unittest.TestCase):
                 "Err": "Invalid purge pattern: 60m:plop:3000m - Pattern components must be numeric with unit suffix"
             },
         )
-        # run the purge with a more complex multi-component save pattern
-        nb_snaps = len(os.listdir(SNAPSHOTS_PATH))
-        resp = self.app.post(
-            "/VolumeDriver.Snapshots.Purge",
-            json.dumps({"Name": name, "Pattern": "60m:120m:180m:240m:300m"}),
-        )
-        self.assertEqual(jsonloads(resp.body), {"Err": ""})
-        # check we deleted 15 snapshots
-        self.assertEqual(len(os.listdir(SNAPSHOTS_PATH)), nb_snaps - 15)
         cleanup_snapshots()
         self.app.post("/VolumeDriver.Remove", json.dumps({"Name": name}))
 
@@ -2017,22 +1998,24 @@ class TestCase(unittest.TestCase):
         self.assertNotEqual(run(["sh", "-c", btrfs.listing_command("/no/such/dir")]).returncode, 0)
 
     def test_compute_purge(self):
-        now = datetime.now()
+        # A frozen instant: timeframes are slices of the calendar, so what a
+        # purge keeps depends on where the snapshots fall in them.
+        now = datetime(2026, 8, 26, 12, 0, 0)
         snapshots = [
             "foobar@" + (now - timedelta(hours=h, minutes=30)).strftime(DTFORMAT)
             for h in range(5000)
         ]
         purge_list = compute_purges(snapshots, Pattern.parse("1d:1w:4w:1y"), now, DTFORMAT)
         not_purged = set(snapshots) - set(purge_list)
-        self.assertEqual(len(not_purged), 40)
+        self.assertEqual(len(not_purged), 42)
 
     def test_compute_purge2(self):
-        now = datetime.now()
+        now = datetime(2026, 8, 26, 12, 0, 0)
         snapshots = ["foobar@" + (now - timedelta(hours=h)).strftime(DTFORMAT) for h in range(3000)]
         for now in [now + timedelta(hours=h) for h in range(3000)]:
             purge_list = compute_purges(snapshots, Pattern.parse("1d:1w:4w:1y"), now, DTFORMAT)
             snapshots = sorted(set(snapshots) - set(purge_list))
-        self.assertEqual(len(snapshots), 4)
+        self.assertEqual(len(snapshots), 5)
 
     def test_schedule_purge(self):
         # create a volume with a file
@@ -2719,6 +2702,10 @@ class TestWhatAPurgeCondemns(unittest.TestCase):
     def condemned(self, names, pattern):
         return compute_purges(names, Pattern.parse(pattern), self.now, DTFORMAT)
 
+    def spared(self, names, pattern):
+        condemned = set(self.condemned(names, pattern))
+        return [name for name in names if name not in condemned]
+
     def test_a_trace_and_the_snapshot_it_was_made_from_are_spared(self):
         t1, t2 = self.aged(3), self.aged(4)
         names = [f"www@{t1}", f"www@{t1}@node2", f"www@{t2}"]
@@ -2745,6 +2732,43 @@ class TestWhatAPurgeCondemns(unittest.TestCase):
         old, young = self.aged(6), self.aged(5)
         names = [f"www@{old}", f"www@{old}@node2", f"www@{young}"]
         self.assertEqual(self.condemned(names, "4h:1d"), [f"www@{young}"])
+
+    def hourly(self, count, minute):
+        """That many hourly snapshots, taken at that minute of the hour"""
+        return [
+            f"www@{(self.now - timedelta(hours=h, minutes=minute)).strftime(DTFORMAT)}"
+            for h in range(count)
+        ]
+
+    def test_the_snapshot_a_timeframe_spares_does_not_change_with_the_clock(self):
+        """The timeframe is a slice of the calendar, not a slice of the age.
+        Numbered on the age, the four hour timeframes would move by forty
+        minutes here, and every snapshot spared in one would be another."""
+        names = self.hourly(20, 20)
+        forty_minutes_later = self.now + timedelta(minutes=40)
+        self.assertEqual(
+            compute_purges(names, Pattern.parse("4h:1d"), self.now, DTFORMAT),
+            compute_purges(names, Pattern.parse("4h:1d"), forty_minutes_later, DTFORMAT),
+        )
+        # the last four hours in full, then the oldest of each four hour slice
+        self.assertEqual(
+            self.spared(names, "4h:1d"),
+            [names[h] for h in (0, 1, 2, 3, 7, 11, 15, 19)],
+        )
+
+    def test_each_component_of_a_pattern_thins_its_own_age_segment(self):
+        """The counts the plugin test used to make on a real filesystem, where
+        they depended on the hour the suite ran at"""
+        names = self.hourly(20, -5) + [f"www@{self.now.strftime(DTFORMAT)}@node2", "www@invalid"]
+        trace, undated = names[-2], names[-1]
+        self.assertEqual(
+            self.spared(names, "2h:4h:8h:16h"),
+            [names[h] for h in (0, 1, 2, 4, 8, 12)] + [trace, undated],
+        )
+        self.assertEqual(
+            self.spared(names, "60m:120m:180m:240m:300m"),
+            [names[h] for h in (0, 1, 2, 3, 4)] + [trace, undated],
+        )
 
 
 class TestScheduledJob(unittest.TestCase):

--- a/test.py
+++ b/test.py
@@ -2756,6 +2756,22 @@ class TestWhatAPurgeCondemns(unittest.TestCase):
             [names[h] for h in (0, 1, 2, 3, 7, 11, 15, 19)],
         )
 
+    def test_a_snapshot_too_old_to_keep_does_not_take_a_live_timeframe(self):
+        """A timeframe is a slice of the calendar, so the slice the pattern
+        ends inside holds both a snapshot too old to keep and a younger one
+        still inside the segment. Letting the first claim the slice would
+        delete the second as its duplicate, and spare nothing at all."""
+        one_oclock = self.now + timedelta(hours=1)
+        names = [
+            f"www@{(one_oclock - timedelta(hours=h, minutes=40)).strftime(DTFORMAT)}"
+            for h in range(26)
+        ]
+        condemned = compute_purges(names, Pattern.parse("4h:1d"), one_oclock, DTFORMAT)
+        # names[24] is forty minutes older than the day the pattern keeps, and
+        # names[23] is the oldest one still inside it, in the same four hour slice
+        self.assertIn(names[24], condemned)
+        self.assertNotIn(names[23], condemned)
+
     def test_each_component_of_a_pattern_thins_its_own_age_segment(self):
         """The counts the plugin test used to make on a real filesystem, where
         they depended on the hour the suite ran at"""
@@ -2763,11 +2779,11 @@ class TestWhatAPurgeCondemns(unittest.TestCase):
         trace, undated = names[-2], names[-1]
         self.assertEqual(
             self.spared(names, "2h:4h:8h:16h"),
-            [names[h] for h in (0, 1, 2, 4, 8, 12)] + [trace, undated],
+            [names[h] for h in (0, 1, 2, 4, 8, 12, 16)] + [trace, undated],
         )
         self.assertEqual(
             self.spared(names, "60m:120m:180m:240m:300m"),
-            [names[h] for h in (0, 1, 2, 3, 4)] + [trace, undated],
+            [names[h] for h in (0, 1, 2, 3, 4, 5)] + [trace, undated],
         )
 
 


### PR DESCRIPTION
A purge keeps one snapshot per timeframe inside each segment of its pattern. That timeframe was numbered on the age of the snapshot, measured from the moment the purge ran, so both bounds of every timeframe moved between two runs and the snapshot spared in a timeframe was rarely the same one twice.

Timeframes are now counted from the 1st of January 1970, on the moment the snapshot was taken. A one day timeframe starts at midnight, a four hour one at 0:00, 4:00, 8:00 and so on, a one week one on a Thursday, and the snapshot spared is the oldest one of its timeframe, still the same one at the next purge.

This is also the foundation for saying how many snapshots a pattern keeps, which is the subject of a separate pull request: as long as the bounds slide, any promised number is only true at the instant it is computed.

## What moves

- Snapshots are ordered on the date they carry rather than on their name, because `DTFORMAT` is a setting and a format that does not sort like a date would leave an arbitrary snapshot of the timeframe alive.
- `test_compute_purge` keeps 42 snapshots instead of 40, and `test_compute_purge2` leaves 5 instead of 4. A segment no longer starts exactly on a timeframe bound, so it spans one timeframe more and keeps one snapshot more, once per middle segment. Both tests freeze their clock now, since what a purge keeps depends on where the snapshots fall in the calendar.
- The two multi component counts `test_purge` asserted through the plugin move to the pure tests, with a frozen clock. Left on a real clock they would have been 12, 13 or 14 depending on the hour the suite ran at.

## Checks

`BUTTERVOLUME_TEST_DIR=... ./test_local.sh`: 131 passed, 11 skipped. `uv run ruff check .` and `uv run ruff format .` clean. The two new pure tests fail on the previous code and pass on this one.
