### PR TITLE
Let a retention step say how many snapshots it keeps

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,20 @@ CHANGELOG
 4.0 (unreleased)
 ****************
 
+- A purge pattern can say how many snapshots it keeps at each step, written
+  ``1h/4:1d/3:1w/4``: one an hour four times, one a day three times, one a
+  week four times, eleven snapshots plus the last hour. Until now ``4h:1d:1w``
+  only said where each step stopped, and knowing how many snapshots it kept
+  meant a division in one's head. A counted step starts where the step before
+  it stopped, so its count is exactly what it says rather than a number
+  sharing the age range of what came before it. A component with no count
+  cannot follow a counted one, since it only says where the next step starts
+  and the ages between the two would belong to no step and be kept for good.
+
+  A snapshot exactly as old as the end of the pattern is now deleted rather
+  than kept. Every age belongs to one step and one only, its end excluded,
+  and the end of the last step is where everything dies.
+
 - A purge numbers its timeframes on the calendar instead of on the age of the
   snapshots. The bounds of a timeframe were counted from the moment the purge
   ran, so they moved from one run to the next and the snapshot spared in a

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,9 +10,12 @@ CHANGELOG
   only said where each step stopped, and knowing how many snapshots it kept
   meant a division in one's head. A counted step starts where the step before
   it stopped, so its count is exactly what it says rather than a number
-  sharing the age range of what came before it. A component with no count
-  cannot follow a counted one, since it only says where the next step starts
-  and the ages between the two would belong to no step and be kept for good.
+  sharing the age range of what came before it. The last component of a
+  pattern, the age past which everything dies, cannot be a component without
+  a count coming after a counted one: the ages between what the counted step
+  covers and what the last one names would belong to no step and be kept for
+  good. In the middle of a pattern a component without a count is still what
+  it always was, the place where the next step starts.
 
   A snapshot exactly as old as the end of the pattern is now deleted rather
   than kept. Every age belongs to one step and one only, its end excluded,

--- a/README.rst
+++ b/README.rst
@@ -661,6 +661,14 @@ list of time length specifiers with a unit. Units can be ``m`` for minutes,
 specifiers must be given from the shortest to the longest, and a pattern of a
 single specifier is allowed.
 
+A specifier can also say how many snapshots it keeps, written
+``<length>/<count>``. A counted specifier starts where the one before it
+stopped, so its count is exactly what it says and the counts add up to what
+the whole pattern keeps. A specifier with no count only says where the next
+one starts, so it cannot follow a counted one: the ages between what the
+counted one covers and what it names would belong to no specifier at all,
+and be kept for good.
+
 Here are a few examples of retention patterns:
 
 - ``4h:1d:2w:2y``
@@ -672,6 +680,19 @@ Here are a few examples of retention patterns:
 - ``4h:1w``
     keep all snapshots during the last four hours, then one snapshot every
     four hours during the first week, then delete older snapshots.
+
+- ``1h/4:1d/3:1w/4``
+    keep all snapshots during the last hour, then one snapshot per hour, four
+    of them, then one per day, three of them, then one per week, four of them,
+    then delete the rest. Eleven snapshots plus the last hour, which is what
+    the counts add up to. Writing ``1h/4:1d`` instead is refused: a specifier
+    with no count says where the next one starts, and there is no next one.
+    The pattern meant there is ``1h/4:1d/3``.
+
+    The counts hold in a steady state, with snapshots taken regularly and each
+    length dividing the next one, which ``1h``, ``1d`` and ``1w`` do. With
+    lengths that do not divide each other, such as ``1h/4:5h/3``, a step can
+    hold one snapshot more.
 
 - ``2h``
     keep all snapshots during the last two hours, then delete older snapshots.

--- a/README.rst
+++ b/README.rst
@@ -664,10 +664,15 @@ single specifier is allowed.
 A specifier can also say how many snapshots it keeps, written
 ``<length>/<count>``. A counted specifier starts where the one before it
 stopped, so its count is exactly what it says and the counts add up to what
-the whole pattern keeps. A specifier with no count only says where the next
-one starts, so it cannot follow a counted one: the ages between what the
-counted one covers and what it names would belong to no specifier at all,
-and be kept for good.
+the whole pattern keeps.
+
+A specifier with no count says where the next one starts, and the last
+specifier of a pattern is the age past which everything is deleted. That last
+one is the only one this matters for: after a counted specifier it would
+leave the ages between what the counted one covers and what it names
+belonging to no specifier at all, kept for good, so it is refused. In the
+middle of a pattern a specifier with no count is fine, and ``1h/48:1d:1w``
+keeps one snapshot a day from where the hours stopped up to one week.
 
 Here are a few examples of retention patterns:
 

--- a/buttervolume/cli.py
+++ b/buttervolume/cli.py
@@ -417,6 +417,14 @@ def main():
             "  then keep 1 snapshot every 4 hours during 1 day,\n"
             "  then keep 1 snapshot every day during the 1st week\n"
             "  then delete snapshots older than 1 week.\n"
+            "A component can also say how many snapshots it keeps, as X/N.\n"
+            "So 1h/4:1d/3:1w/4 means:\n"
+            "  Keep all snapshots in the last hour,\n"
+            "  then keep 1 snapshot per hour, 4 of them,\n"
+            "  then keep 1 snapshot per day, 3 of them,\n"
+            "  then keep 1 snapshot per week, 4 of them,\n"
+            "  then delete the rest: 11 snapshots, plus the last hour.\n"
+            "A component with no count cannot follow a counted one.\n"
         ),
     )
     parser_purge.add_argument(

--- a/buttervolume/cli.py
+++ b/buttervolume/cli.py
@@ -424,7 +424,7 @@ def main():
             "  then keep 1 snapshot per day, 3 of them,\n"
             "  then keep 1 snapshot per week, 4 of them,\n"
             "  then delete the rest: 11 snapshots, plus the last hour.\n"
-            "A component with no count cannot follow a counted one.\n"
+            "The last component cannot be a count-less one after a counted one.\n"
         ),
     )
     parser_purge.add_argument(

--- a/buttervolume/purge.py
+++ b/buttervolume/purge.py
@@ -2,11 +2,23 @@
 
 A pattern is written ``4h:1d:2w``: keep everything from the last four hours,
 then one snapshot every four hours up to a day, then one a day up to two
-weeks, then nothing. A pattern of a single specifier, ``2h``, keeps the last
-two hours and deletes the rest.
+weeks, then nothing. A component can say how many snapshots it keeps instead
+of where the next one starts: ``1h/4:1d/3:1w/4`` keeps everything from the
+last hour, then one an hour for four hours, then one a day for three days,
+then one a week for four weeks, then nothing, which is eleven snapshots plus
+the last hour. A counted component starts where the one before it stopped,
+so the count is what it says and adding them up says what the pattern keeps.
+A pattern of a single specifier, ``2h``, keeps the last two hours and deletes
+the rest.
 
-Older versions accepted ``2h:2h`` for that last one. Such a pattern is read
-back here as the ``2h`` it means, and the original spelling is kept in
+A component with no count only says where the next one starts, so the last
+one is the age past which everything dies. That is why it cannot follow a
+counted component: what the counted one ends and what the last one names
+would leave an age range belonging to no step, kept forever without anyone
+asking for it. ``1h/4:1d`` is refused, ``1h/4:1d/3`` is the pattern meant.
+
+Older versions accepted ``2h:2h`` for a single duration. Such a pattern is
+read back here as the ``2h`` it means, and the original spelling is kept in
 ``deprecated`` so the caller can decide what to do with it: an immediate purge
 refuses it, a schedule still accepts it as it is written, and the scheduler
 converts it and says so at every run.
@@ -33,41 +45,98 @@ EPOCH = datetime(1970, 1, 1)
 
 
 @dataclass(frozen=True)
-class Pattern:
-    """A retention pattern, read: its durations in minutes and its spelling.
+class Step:
+    """A slice of ages where the pattern keeps one snapshot per timeframe.
 
-    It is only built by parse(), so `minutes` is always strictly ascending and
-    a caller never has to wonder whether the pattern it holds was checked.
+    `width` is how wide a timeframe is, `start` and `end` are the ages the
+    step covers, the end excluded. How many snapshots it keeps is
+    `(end - start) // width`, which is the count a component spells out.
     """
 
-    minutes: tuple[int, ...]
+    width: int
+    start: int
+    end: int
+
+
+@dataclass(frozen=True)
+class Pattern:
+    """A retention pattern, read: the steps it thins, and where it stops.
+
+    It is only built by parse(), so the steps follow each other without a gap
+    and a caller never has to wonder whether the pattern it holds was checked.
+    Anything younger than the first step is kept, anything as old as `cutoff`
+    is deleted, and `cutoff` is where the last step ends.
+    """
+
+    steps: tuple[Step, ...]
+    cutoff: int
     text: str
     deprecated: str | None = None
 
     @classmethod
     def parse(cls, text):
         components = text.split(":")
-        # isdecimal, not isnumeric: "²".isnumeric() is True and int("²") raises,
-        # and a pattern nobody can apply must not leave here as a ValueError
-        if not all(c[:-1].isdecimal() for c in components):
-            raise ValidationError(
-                f"Invalid purge pattern: {text} - "
-                "Pattern components must be numeric with unit suffix"
-            )
+        durations = []
+        counts = []
         for c in components:
-            if c[-1] not in UNITS:
-                raise ValidationError(f"Invalid purge pattern: {text} - unknown unit '{c[-1]}'")
-        minutes = tuple(int(c[:-1]) * UNITS[c[-1]] for c in components)
+            duration, counted, count = c.partition("/")
+            # isdecimal, not isnumeric: "²".isnumeric() is True and int("²") raises,
+            # and a pattern nobody can apply must not leave here as a ValueError
+            if not duration[:-1].isdecimal():
+                raise ValidationError(
+                    f"Invalid purge pattern: {text} - "
+                    "Pattern components must be numeric with unit suffix"
+                )
+            if duration[-1] not in UNITS:
+                raise ValidationError(
+                    f"Invalid purge pattern: {text} - unknown unit '{duration[-1]}'"
+                )
+            if counted and not (count.isdecimal() and int(count) >= 1):
+                raise ValidationError(
+                    f"Invalid purge pattern: {text} - a count is how many snapshots the "
+                    "component keeps, a whole number of at least one, as in 1h/4"
+                )
+            durations.append(int(duration[:-1]) * UNITS[duration[-1]])
+            counts.append(int(count) if counted else None)
 
-        if len(components) == 2 and components[0] == components[1]:
-            return cls(minutes[:1], components[0], deprecated=text)
+        if len(components) == 2 and components[0] == components[1] and counts == [None, None]:
+            return cls((), durations[0], components[0], deprecated=text)
 
-        if not all(x < y for x, y in zip(minutes, minutes[1:])):
+        if not all(x < y for x, y in zip(durations, durations[1:])):
             raise ValidationError(
                 f"Invalid purge pattern: {text} - "
                 "Time values must be in ascending order (e.g., 2h:4h:8h or 30m:2h:1d)"
             )
-        return cls(minutes, text)
+
+        steps = []
+        # everything younger than the first component is kept, so the first
+        # step starts there and each one after starts where the last stopped
+        start = durations[0]
+        for i, (duration, count) in enumerate(zip(durations, counts)):
+            last = i == len(components) - 1
+            if count:
+                end = start + duration * count
+            elif not last:
+                end = durations[i + 1]
+            elif i and counts[i - 1]:
+                raise ValidationError(
+                    f"Invalid purge pattern: {text} - '{components[i]}' must say how many "
+                    f"snapshots it keeps, as in '{components[i]}/3', because the component "
+                    "before it does. Without a count it only says where a step stops, and "
+                    "the ages between the two would belong to no step at all"
+                )
+            else:
+                # a last component with no count is the age past which
+                # everything dies, and the last step already stops there
+                break
+            if end <= start:
+                raise ValidationError(
+                    f"Invalid purge pattern: {text} - the components before "
+                    f"'{components[i]}' already keep snapshots older than it does"
+                )
+            steps.append(Step(duration, start, end))
+            start = end
+        return cls(tuple(steps), start, text)
 
     def __str__(self):
         return self.text
@@ -76,7 +145,7 @@ class Pattern:
 def compute_purges(snapshots, pattern, now, dtformat):
     """Return the list of snapshots this pattern condemns, at this moment.
 
-    Inside a segment the pattern keeps one snapshot per timeframe, and that
+    Inside a step the pattern keeps one snapshot per timeframe, and that
     timeframe is counted from the epoch, on the moment the snapshot was taken.
     Counting it on the age would move every boundary at every run, and the
     snapshot spared in a timeframe would not be the same one twice.
@@ -94,9 +163,6 @@ def compute_purges(snapshots, pattern, now, dtformat):
         if s.host:
             needed.add(str(s))
             needed.add(str(s.without_host()))
-    ages = list(reversed(pattern.minutes))
-    purge_list = []
-    max_age = ages[0]
     # Each snapshot with the moment it was taken and its age in minutes.
     # Example : [(datetime(2026, 8, 26, 11, 30), "www@...", 30), ...]
     # Ordered on that moment and not on the name, because the date format is a
@@ -111,34 +177,19 @@ def compute_purges(snapshots, pattern, now, dtformat):
             continue
         dated.append((taken, s, int((now - taken).total_seconds()) / 60))
     dated.sort()
-    # A single specifier ("2h" -> [120]) deletes everything past the threshold
-    if len(ages) == 1:
-        purge_list = [s for _, s, age in dated if age > ages[0]]
-    else:
-        # Several specifiers ("2h:1d:1w" -> [10080, 1440, 120]) keep one snapshot
-        # per timeframe inside each segment.
-        # age segments = [(10080, 1440), (1440, 120)]
-        for age_segment in [(ages[i], ages[i + 1]) for i, _ in enumerate(ages[:-1])]:
-            last_timeframe = None
-            for taken, s, age in dated:
-                # if the age is outside the age_segment, delete nothing.
-                # Only 70 and 90 are inside the age_segment (60, 180)
-                if age > age_segment[0] < max_age or age < age_segment[1]:
-                    continue
-                # Past the oldest duration of the pattern everything dies, and
-                # without claiming a timeframe: a timeframe is a slice of the
-                # calendar, so it can hold both a snapshot too old to keep and
-                # a younger one still inside the segment, and the second would
-                # be deleted as a duplicate of the first with nothing spared.
-                if age > max_age:
-                    purge_list.append(s)
-                    continue
-                # Now get the timeframe number of the snapshot: the slice of
-                # the calendar it was taken in, as wide as this segment steps,
-                # and not the slice its age falls in today.
-                timeframe = (taken - EPOCH) // timedelta(minutes=age_segment[1])
-                # delete if we already had a snapshot in the same timeframe
-                if timeframe == last_timeframe:
-                    purge_list.append(s)
-                last_timeframe = timeframe
+    # past the end of the pattern nothing survives
+    purge_list = [s for _, s, age in dated if age >= pattern.cutoff]
+    for step in pattern.steps:
+        last_timeframe = None
+        for taken, s, age in dated:
+            if not step.start <= age < step.end:
+                continue
+            # the timeframe number of the snapshot: the slice of the calendar
+            # it was taken in, as wide as this step steps, and not the slice
+            # its age falls in today
+            timeframe = (taken - EPOCH) // timedelta(minutes=step.width)
+            # delete if we already had a snapshot in the same timeframe
+            if timeframe == last_timeframe:
+                purge_list.append(s)
+            last_timeframe = timeframe
     return [s for s in purge_list if s not in needed]

--- a/buttervolume/purge.py
+++ b/buttervolume/purge.py
@@ -11,11 +11,14 @@ so the count is what it says and adding them up says what the pattern keeps.
 A pattern of a single specifier, ``2h``, keeps the last two hours and deletes
 the rest.
 
-A component with no count only says where the next one starts, so the last
-one is the age past which everything dies. That is why it cannot follow a
-counted component: what the counted one ends and what the last one names
-would leave an age range belonging to no step, kept forever without anyone
-asking for it. ``1h/4:1d`` is refused, ``1h/4:1d/3`` is the pattern meant.
+A component with no count says where the next step starts, and the last
+component of all is the age past which everything dies. That last one is the
+only one a count changes anything for: coming after a counted component, what
+the counted one covers and what it names would leave a range of ages
+belonging to no step, kept for good although the pattern says the opposite.
+``1h/4:1d`` is refused for that, and ``1h/4:1d/3`` is the pattern meant. In
+the middle of a pattern a component with no count is fine: ``1h/48:1d:1w``
+thins by the day from where the hours stopped up to a week.
 
 Older versions accepted ``2h:2h`` for a single duration. Such a pattern is
 read back here as the ``2h`` it means, and the original spelling is kept in
@@ -96,6 +99,11 @@ class Pattern:
                     f"Invalid purge pattern: {text} - a count is how many snapshots the "
                     "component keeps, a whole number of at least one, as in 1h/4"
                 )
+            if not int(duration[:-1]):
+                raise ValidationError(
+                    f"Invalid purge pattern: {text} - '{c}' lasts no time at all, and a "
+                    "step of no length would hold every snapshot in the same timeframe"
+                )
             durations.append(int(duration[:-1]) * UNITS[duration[-1]])
             counts.append(int(count) if counted else None)
 
@@ -118,6 +126,11 @@ class Pattern:
                 end = start + duration * count
             elif not last:
                 end = durations[i + 1]
+                if end <= start:
+                    raise ValidationError(
+                        f"Invalid purge pattern: {text} - the components before "
+                        f"'{components[i + 1]}' already keep snapshots older than it does"
+                    )
             elif i and counts[i - 1]:
                 raise ValidationError(
                     f"Invalid purge pattern: {text} - '{components[i]}' must say how many "
@@ -129,11 +142,6 @@ class Pattern:
                 # a last component with no count is the age past which
                 # everything dies, and the last step already stops there
                 break
-            if end <= start:
-                raise ValidationError(
-                    f"Invalid purge pattern: {text} - the components before "
-                    f"'{components[i]}' already keep snapshots older than it does"
-                )
             steps.append(Step(duration, start, end))
             start = end
         return cls(tuple(steps), start, text)

--- a/test.py
+++ b/test.py
@@ -2672,20 +2672,64 @@ class TestWhatToRestore(unittest.TestCase):
 class TestPurgePattern(unittest.TestCase):
     """The retention pattern, read without touching a filesystem"""
 
-    def test_a_pattern_is_read_as_the_durations_it_names(self):
-        self.assertEqual(Pattern.parse("2h").minutes, (120,))
-        self.assertEqual(Pattern.parse("30m:2h:1d:1w:1y").minutes, (30, 120, 1440, 10080, 525600))
+    def steps(self, text):
+        return [(step.width, step.start, step.end) for step in Pattern.parse(text).steps]
+
+    def test_a_pattern_is_read_as_the_steps_it_thins(self):
+        self.assertEqual(self.steps("2h"), [])
+        self.assertEqual(Pattern.parse("2h").cutoff, 120)
+        self.assertEqual(
+            self.steps("30m:2h:1d:1w:1y"),
+            [(30, 30, 120), (120, 120, 1440), (1440, 1440, 10080), (10080, 10080, 525600)],
+        )
+        self.assertEqual(Pattern.parse("30m:2h:1d:1w:1y").cutoff, 525600)
         self.assertEqual(str(Pattern.parse("4h:1d")), "4h:1d")
         self.assertIsNone(Pattern.parse("4h:1d").deprecated)
 
+    def test_a_counted_component_starts_where_the_one_before_it_stops(self):
+        """Four hours of hourly snapshots, then three days of daily ones, then
+        four weeks of weekly ones: eleven snapshots, and the counts say so"""
+        self.assertEqual(
+            self.steps("1h/4:1d/3:1w/4"),
+            [(60, 60, 300), (1440, 300, 4620), (10080, 4620, 44940)],
+        )
+        self.assertEqual(Pattern.parse("1h/4:1d/3:1w/4").cutoff, 44940)
+
+    def test_a_component_with_no_count_says_where_the_next_one_starts(self):
+        """Counted or not, one step starts where the one before it stopped"""
+        self.assertEqual(self.steps("1h/48:1d:1w"), [(60, 60, 2940), (1440, 2940, 10080)])
+        self.assertEqual(Pattern.parse("1h/48:1d:1w").cutoff, 10080)
+
     def test_the_old_way_of_writing_a_single_duration_is_read_as_that_duration(self):
         pattern = Pattern.parse("2h:2h")
-        self.assertEqual(pattern.minutes, (120,))
+        self.assertEqual(pattern.steps, ())
+        self.assertEqual(pattern.cutoff, 120)
         self.assertEqual(pattern.text, "2h")
         self.assertEqual(pattern.deprecated, "2h:2h")
 
     def test_a_pattern_nobody_could_apply_is_refused(self):
-        for text in ("", "2h:", "60m:plop:3000m", "5x", "²h", "4h:2h", "2h:120m", "2h:2h:4h"):
+        for text in (
+            "",
+            "2h:",
+            "60m:plop:3000m",
+            "5x",
+            "²h",
+            "4h:2h",
+            "2h:120m",
+            "2h:2h:4h",
+            # a count is a whole number of snapshots, at least one
+            "1h/0",
+            "1h/",
+            "1h/2h",
+            "1h/x",
+            # two components of the same duration, counted this time
+            "1h/4:1h/4",
+            # a last component with no count after a counted one would leave
+            # the ages between five hours and a day belonging to no step
+            "1h/4:1d",
+            # the counted component already reaches past two days
+            "1h/48:1d:2d",
+        ):
             with self.assertRaises(ValidationError):
                 Pattern.parse(text)
 
@@ -2755,6 +2799,19 @@ class TestWhatAPurgeCondemns(unittest.TestCase):
             self.spared(names, "4h:1d"),
             [names[h] for h in (0, 1, 2, 3, 7, 11, 15, 19)],
         )
+
+    def test_a_counted_pattern_keeps_what_its_counts_add_up_to(self):
+        """Ninety days of hourly snapshots, purged every hour on the half hour:
+        1h/4:1d/3:1w/4 promises eleven snapshots, plus the last hour, and the
+        purge that never stops running keeps exactly that"""
+        pattern = Pattern.parse("1h/4:1d/3:1w/4")
+        kept = []
+        for hour in range(90 * 24):
+            moment = self.now + timedelta(hours=hour)
+            kept.append(f"www@{moment.strftime(DTFORMAT)}")
+            condemned = set(compute_purges(kept, pattern, moment + timedelta(minutes=30), DTFORMAT))
+            kept = [name for name in kept if name not in condemned]
+        self.assertEqual(len(kept), 4 + 3 + 4 + 1)
 
     def test_a_snapshot_too_old_to_keep_does_not_take_a_live_timeframe(self):
         """A timeframe is a slice of the calendar, so the slice the pattern

--- a/test.py
+++ b/test.py
@@ -2729,6 +2729,8 @@ class TestPurgePattern(unittest.TestCase):
             "1h/4:1d",
             # the counted component already reaches past two days
             "1h/48:1d:2d",
+            # a step of no length would hold every snapshot in one timeframe
+            "0m:1h",
         ):
             with self.assertRaises(ValidationError):
                 Pattern.parse(text)


### PR DESCRIPTION
A retention pattern only said where each of its steps stopped, so reading `4h:1d:1w` as a number of snapshots meant a division in one's head. A component can now carry a count.

`1h/4:1d/3:1w/4` keeps one snapshot an hour four times, one a day three times and one a week four times: eleven snapshots plus the last hour, which is exactly what the counts add up to.

## The rules

- A counted step starts where the step before it stopped, not at its own duration. Counted from the duration, as the fork this idea comes from does, `1h/24:1d/3` would cover one day and then three, so the second count would be a lie, and `1h/48:1d/2` would be refused although it makes sense.
- A component with no count only says where the next step starts, so it cannot follow a counted one. The ages between what the counted step covers and what the uncounted one names would belong to no step and be kept for good. `1h/4:1d` is refused and names `1h/4:1d/3` as the pattern meant.
- A count is a whole number of at least one. Durations must still ascend, which is what refuses `1h/4:1h/4`.
- Every pattern already written keeps the steps and the cutoff it has today.

## What moves inside

A pattern is now read as the steps it thins and the age past which everything dies, rather than as the list of durations it was written with. Each step carries the ages it covers, so `compute_purges` reads them instead of pairing durations up again, and the steps follow each other without a gap by construction.

Every age belongs to one step and one only, its end excluded, so a snapshot exactly as old as the end of the pattern is deleted rather than kept.

## Checks

`BUTTERVOLUME_TEST_DIR=... ./test_local.sh`: 135 passed, 11 skipped, with no expected count of the existing tests moved. `uv run ruff check .` and `uv run ruff format .` clean.

A new test runs the steady state the counts promise: ninety days of hourly snapshots, purged every hour on the half hour with `1h/4:1d/3:1w/4`, and it keeps twelve snapshots, the eleven the counts add up to plus the last hour.
